### PR TITLE
Remove JSON string (de)serialization and rework Python signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 /dist/
 /vl-convert-python/notebooks/.ipynb_checkpoints/
 /vl-convert-python/notebooks/output/
+/vl-convert/tests/output/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pythonize"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7f0c136f5fbc01868185eef462800e49659eb23acca83b9e884367a006acb6"
+dependencies = [
+ "pyo3",
+ "serde",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,6 +3865,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "pyo3",
+ "pythonize",
  "vl-convert-rs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c2ca00549910ec251e3bd15f87aeeb206c9456b9a77b43ff6c97c54042a472"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +304,17 @@ checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -986,6 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1067,12 @@ dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -1179,6 +1216,9 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fly-accept-encoding"
@@ -2078,6 +2118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2454,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2722,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -3347,6 +3429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,7 +3940,10 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "vl-convert"
 version = "0.3.2"
 dependencies = [
+ "assert_cmd",
  "clap",
+ "predicates",
+ "rstest",
  "serde_json",
  "tokio",
  "vl-convert-rs",
@@ -3894,6 +3985,15 @@ name = "vl-convert-vendor"
 version = "0.3.2"
 dependencies = [
  "serde_json",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/vl-convert-python/Cargo.toml
+++ b/vl-convert-python/Cargo.toml
@@ -21,3 +21,5 @@ vl-convert-rs = { path = "../vl-convert-rs", version= "0.3.0-rc1" }
 pyo3 = { version = "0.17.1", features = ["extension-module", "anyhow"] }
 lazy_static = "1.4.0"
 futures = "0.3.24"
+pythonize = "0.17.0"
+

--- a/vl-convert-python/README.md
+++ b/vl-convert-python/README.md
@@ -22,6 +22,7 @@ The `vegalite_to_svg` and `vegalite_to_png` functions can be used to convert Veg
 
 ```python
 import vl_convert as vlc
+import json
 
 vl_spec = r"""
 {
@@ -55,7 +56,7 @@ with open("chart.png", "wb") as f:
 # Create low-level Vega representation of chart and write to file
 vg_spec = vlc.vegalite_to_vega(vl_spec)
 with open("chart.vg.json", "wt") as f:
-    f.write(vg_spec)
+    json.dump(vg_spec, f)
 ```
 
 ## Convert Altair Chart to SVG, PNG, and Vega
@@ -65,6 +66,7 @@ The Altair visualization library provides a Pythonic API for generating Vega-Lit
 import altair as alt
 from vega_datasets import data
 import vl_convert as vlc
+import json
 
 source = data.barley()
 
@@ -87,7 +89,7 @@ with open("altair_chart.png", "wb") as f:
 # Create low-level Vega representation of chart and write to file
 vg_spec = vlc.vegalite_to_vega(chart.to_json(), vl_version="4.17")
 with open("altair_chart.vg.json", "wt") as f:
-    f.write(vg_spec)
+    json.dump(vg_spec, f)
 ```
 # How it works
 This crate uses [PyO3](https://pyo3.rs/) to wrap the [`vl-convert-rs`](https://crates.io/crates/vl-convert-rs) Rust crate as a Python library. The `vl-convert-rs` crate is a self-contained Rust library for converting [Vega-Lite](https://vega.github.io/vega-lite/) visualization specifications into various formats.  The conversions are performed using the Vega-Lite and Vega JavaScript libraries running in a v8 JavaScript runtime provided by the [`deno_runtime`](https://crates.io/crates/deno_runtime) crate.  Font metrics and SVG-to-PNG conversions are provided by the [`resvg`](https://crates.io/crates/resvg) crate.

--- a/vl-convert-python/notebooks/convert_vegalite.ipynb
+++ b/vl-convert-python/notebooks/convert_vegalite.ipynb
@@ -61,6 +61,7 @@
    "outputs": [],
    "source": [
     "import vl_convert as vlc\n",
+    "import json\n",
     "\n",
     "vl_spec = r\"\"\"\n",
     "{\n",
@@ -157,7 +158,7 @@
    "source": [
     "vg_spec = vlc.vegalite_to_vega(vl_spec)\n",
     "with open(\"output/chart.vg.json\", \"wt\") as f:\n",
-    "    f.write(vg_spec)"
+    "    json.dump(vg_spec, f)"
    ]
   },
   {
@@ -283,7 +284,7 @@
    "source": [
     "vg_spec = vlc.vegalite_to_vega(chart.to_json(), vl_version=\"4.17\")\n",
     "with open(\"output/altair_chart.vg.json\", \"wt\") as f:\n",
-    "    f.write(vg_spec)"
+    "    json.dump(vg_spec, f)"
    ]
   },
   {

--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::types::{PyBytes, PyDict, PyString};
+use pythonize::depythonize;
 use std::str::FromStr;
 use std::sync::Mutex;
 use vl_convert_rs::converter::TOKIO_RUNTIME;
@@ -20,7 +21,7 @@ lazy_static! {
 /// version of the Vega-Lite JavaScript library.
 ///
 /// Args:
-///     vl_spec (str): Vega-Lite JSON specification string
+///     vl_spec (str | dict): Vega-Lite JSON specification string or dict
 ///     vl_version (str): Vega-Lite library version string (e.g. 'v5.5')
 ///         (default to latest)
 ///     pretty (bool): If True, pretty-print resulting Vega JSON
@@ -31,25 +32,19 @@ lazy_static! {
 #[pyfunction]
 #[pyo3(text_signature = "(vl_spec, vl_version, pretty)")]
 fn vegalite_to_vega(
-    vl_spec: &str,
+    vl_spec: PyObject,
     vl_version: Option<&str>,
     pretty: Option<bool>,
 ) -> PyResult<String> {
+    let vl_spec = parse_json_spec(vl_spec)?;
+
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
     } else {
         Default::default()
     };
     let pretty = pretty.unwrap_or(false);
-    let vl_spec = match serde_json::from_str::<serde_json::Value>(vl_spec) {
-        Ok(vl_spec) => vl_spec,
-        Err(err) => {
-            return Err(PyValueError::new_err(format!(
-                "Failed to parse vl_spec as JSON: {}",
-                err
-            )))
-        }
-    };
+
     let mut converter = VL_CONVERTER
         .lock()
         .expect("Failed to acquire lock on Vega-Lite converter");
@@ -69,7 +64,7 @@ fn vegalite_to_vega(
 /// Convert a Vega spec to an SVG image string
 ///
 /// Args:
-///     vg_spec (str): Vega JSON specification string
+///     vg_spec (str | dict): Vega JSON specification string or dict
 ///
 /// Returns:
 ///     str: SVG image string
@@ -106,7 +101,7 @@ fn vega_to_svg(vg_spec: &str) -> PyResult<String> {
 /// particular version of the Vega-Lite JavaScript library.
 ///
 /// Args:
-///     vl_spec (str): Vega-Lite JSON specification string
+///     vl_spec (str | dict): Vega-Lite JSON specification string or dict
 ///     vl_version (str): Vega-Lite library version string (e.g. 'v5.5')
 ///         (default to latest)
 ///
@@ -114,20 +109,13 @@ fn vega_to_svg(vg_spec: &str) -> PyResult<String> {
 ///     str: SVG image string
 #[pyfunction]
 #[pyo3(text_signature = "(vl_spec, vl_version)")]
-fn vegalite_to_svg(vl_spec: &str, vl_version: Option<&str>) -> PyResult<String> {
+fn vegalite_to_svg(vl_spec: PyObject, vl_version: Option<&str>) -> PyResult<String> {
+    let vl_spec = parse_json_spec(vl_spec)?;
+
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
     } else {
         Default::default()
-    };
-    let vl_spec = match serde_json::from_str::<serde_json::Value>(vl_spec) {
-        Ok(vl_spec) => vl_spec,
-        Err(err) => {
-            return Err(PyValueError::new_err(format!(
-                "Failed to parse vl_spec as JSON: {}",
-                err
-            )))
-        }
     };
 
     let mut converter = VL_CONVERTER
@@ -149,23 +137,15 @@ fn vegalite_to_svg(vl_spec: &str, vl_version: Option<&str>) -> PyResult<String> 
 /// Convert a Vega spec to PNG image data.
 ///
 /// Args:
-///     vg_spec (str): Vega JSON specification string
+///     vg_spec (str | dict): Vega JSON specification string or dict
 ///     scale (float): Image scale factor (default 1.0)
 ///
 /// Returns:
 ///     bytes: PNG image data
 #[pyfunction]
 #[pyo3(text_signature = "(vg_spec, scale)")]
-fn vega_to_png(vg_spec: &str, scale: Option<f32>) -> PyResult<PyObject> {
-    let vg_spec = match serde_json::from_str::<serde_json::Value>(vg_spec) {
-        Ok(vg_spec) => vg_spec,
-        Err(err) => {
-            return Err(PyValueError::new_err(format!(
-                "Failed to parse vg_spec as JSON: {}",
-                err
-            )))
-        }
-    };
+fn vega_to_png(vg_spec: PyObject, scale: Option<f32>) -> PyResult<PyObject> {
+    let vg_spec = parse_json_spec(vg_spec)?;
 
     let mut converter = VL_CONVERTER
         .lock()
@@ -190,7 +170,7 @@ fn vega_to_png(vg_spec: &str, scale: Option<f32>) -> PyResult<PyObject> {
 /// version of the Vega-Lite JavaScript library.
 ///
 /// Args:
-///     vl_spec (str): Vega-Lite JSON specification string
+///     vl_spec (str | dict): Vega-Lite JSON specification string or dict
 ///     vl_version (str): Vega-Lite library version string (e.g. 'v5.5')
 ///         (default to latest)
 ///     scale (float): Image scale factor (default 1.0)
@@ -200,7 +180,7 @@ fn vega_to_png(vg_spec: &str, scale: Option<f32>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(text_signature = "(vl_spec, vl_version, scale)")]
 fn vegalite_to_png(
-    vl_spec: &str,
+    vl_spec: PyObject,
     vl_version: Option<&str>,
     scale: Option<f32>,
 ) -> PyResult<PyObject> {
@@ -209,15 +189,7 @@ fn vegalite_to_png(
     } else {
         Default::default()
     };
-    let vl_spec = match serde_json::from_str::<serde_json::Value>(vl_spec) {
-        Ok(vl_spec) => vl_spec,
-        Err(err) => {
-            return Err(PyValueError::new_err(format!(
-                "Failed to parse vg_spec as JSON: {}",
-                err
-            )))
-        }
-    };
+    let vl_spec = parse_json_spec(vl_spec)?;
 
     let mut converter = VL_CONVERTER
         .lock()
@@ -237,6 +209,35 @@ fn vegalite_to_png(
     Ok(Python::with_gil(|py| -> PyObject {
         PyObject::from(PyBytes::new(py, png_data.as_slice()))
     }))
+}
+
+/// Helper function to parse an input Python string or dict as a serde_json::Value
+fn parse_json_spec(vl_spec: PyObject) -> PyResult<serde_json::Value> {
+    Python::with_gil(|py| -> PyResult<serde_json::Value> {
+        if let Ok(vl_spec) = vl_spec.extract::<&str>(py) {
+            match serde_json::from_str::<serde_json::Value>(vl_spec) {
+                Ok(vl_spec) => Ok(vl_spec),
+                Err(err) => {
+                    return Err(PyValueError::new_err(format!(
+                        "Failed to parse vl_spec string as JSON: {}",
+                        err
+                    )))
+                }
+            }
+        } else if let Ok(vl_spec) = vl_spec.cast_as::<PyDict>(py) {
+            match depythonize(vl_spec) {
+                Ok(vl_spec) => Ok(vl_spec),
+                Err(err) => {
+                    return Err(PyValueError::new_err(format!(
+                        "Failed to parse vl_spec dict as JSON: {}",
+                        err
+                    )))
+                }
+            }
+        } else {
+            return Err(PyValueError::new_err("vl_spec must be a string or dict"));
+        }
+    })
 }
 
 /// Register a directory of fonts for use in subsequent conversions

--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -205,25 +205,21 @@ fn parse_json_spec(vl_spec: PyObject) -> PyResult<serde_json::Value> {
         if let Ok(vl_spec) = vl_spec.extract::<&str>(py) {
             match serde_json::from_str::<serde_json::Value>(vl_spec) {
                 Ok(vl_spec) => Ok(vl_spec),
-                Err(err) => {
-                    return Err(PyValueError::new_err(format!(
-                        "Failed to parse vl_spec string as JSON: {}",
-                        err
-                    )))
-                }
+                Err(err) => Err(PyValueError::new_err(format!(
+                    "Failed to parse vl_spec string as JSON: {}",
+                    err
+                ))),
             }
         } else if let Ok(vl_spec) = vl_spec.cast_as::<PyDict>(py) {
             match depythonize(vl_spec) {
                 Ok(vl_spec) => Ok(vl_spec),
-                Err(err) => {
-                    return Err(PyValueError::new_err(format!(
-                        "Failed to parse vl_spec dict as JSON: {}",
-                        err
-                    )))
-                }
+                Err(err) => Err(PyValueError::new_err(format!(
+                    "Failed to parse vl_spec dict as JSON: {}",
+                    err
+                ))),
             }
         } else {
-            return Err(PyValueError::new_err("vl_spec must be a string or dict"));
+            Err(PyValueError::new_err("vl_spec must be a string or dict"))
         }
     })
 }

--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 import vl_convert as vlc
 import pytest
@@ -48,8 +49,13 @@ def load_expected_png(name, vl_version):
     "vl_version", ["v4_17", "v5_0", "v5_1", "v5_2", "v5_3", "v5_4", "v5_5"]
 )
 @pytest.mark.parametrize("pretty", [True, False])
-def test_reference_specs(name, vl_version, pretty):
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_vega(name, vl_version, pretty, as_dict):
     vl_spec = load_vl_spec(name)
+
+    if as_dict:
+        vl_spec = json.loads(vl_spec)
+
     expected_vg_spec = load_expected_vg_spec(name, vl_version, pretty)
 
     if expected_vg_spec is None:
@@ -61,9 +67,14 @@ def test_reference_specs(name, vl_version, pretty):
 
 
 @pytest.mark.parametrize("name", ["circle_binned", "stacked_bar_h"])
-def test_svg(name):
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_svg(name, as_dict):
     vl_version = "v5_5"
     vl_spec = load_vl_spec(name)
+
+    if as_dict:
+        vl_spec = json.loads(vl_spec)
+
     expected_svg = load_expected_svg(name, vl_version)
 
     # Convert to vega first
@@ -77,9 +88,14 @@ def test_svg(name):
 
 
 @pytest.mark.parametrize("name,scale", [("circle_binned", 1.0), ("stacked_bar_h", 2.0)])
-def test_png(name, scale):
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_png(name, scale, as_dict):
     vl_version = "v5_5"
     vl_spec = load_vl_spec(name)
+
+    if as_dict:
+        vl_spec = json.loads(vl_spec)
+
     expected_png = load_expected_png(name, vl_version)
 
     # Convert to vega first

--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -20,12 +20,12 @@ def load_vl_spec(name):
     return spec_str
 
 
-def load_expected_vg_spec(name, vl_version, pretty):
-    filename = f"{name}.vg.pretty.json" if pretty else f"{name}.vg.json"
+def load_expected_vg_spec(name, vl_version):
+    filename = f"{name}.vg.json"
     spec_path = specs_dir / "expected" / vl_version / filename
     if spec_path.exists():
         with spec_path.open("rt", encoding="utf8") as f:
-            return f.read()
+            return json.load(f)
     else:
         return None
 
@@ -48,21 +48,20 @@ def load_expected_png(name, vl_version):
 @pytest.mark.parametrize(
     "vl_version", ["v4_17", "v5_0", "v5_1", "v5_2", "v5_3", "v5_4", "v5_5"]
 )
-@pytest.mark.parametrize("pretty", [True, False])
 @pytest.mark.parametrize("as_dict", [False, True])
-def test_vega(name, vl_version, pretty, as_dict):
+def test_vega(name, vl_version, as_dict):
     vl_spec = load_vl_spec(name)
 
     if as_dict:
         vl_spec = json.loads(vl_spec)
 
-    expected_vg_spec = load_expected_vg_spec(name, vl_version, pretty)
+    expected_vg_spec = load_expected_vg_spec(name, vl_version)
 
     if expected_vg_spec is None:
         with pytest.raises(ValueError):
-            vlc.vegalite_to_vega(vl_spec, vl_version=vl_version, pretty=pretty)
+            vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
     else:
-        vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version, pretty=pretty)
+        vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
         assert expected_vg_spec == vg_spec
 
 

--- a/vl-convert-rs/Cargo.toml
+++ b/vl-convert-rs/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["Visualization", "Vega", "Vega-Lite"]
 [dependencies]
 deno_runtime = "0.80.0"
 deno_core = "0.154.0"
-serde_json = "1.0.85"
+serde_json = {version="1.0.85", features=["preserve_order"]}
 serde = {version="1.0.145", features=["derive"]}
 futures = "0.3.24"
 futures-util = "0.3.24"

--- a/vl-convert-rs/examples/conversion1.rs
+++ b/vl-convert-rs/examples/conversion1.rs
@@ -26,7 +26,7 @@ async fn main() {
     .unwrap();
 
     let vega_spec = converter
-        .vegalite_to_vega(vl_spec, VlVersion::v5_5, true)
+        .vegalite_to_vega(vl_spec, VlVersion::v5_5)
         .await
         .expect("Failed to perform Vega-Lite to Vega conversion");
 

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -436,7 +436,7 @@ pub enum VlConvertCommand {
 /// }   "#).unwrap();
 ///
 ///     let vega_spec = futures::executor::block_on(
-///         converter.vegalite_to_vega(vl_spec, VlVersion::v5_5, true)
+///         converter.vegalite_to_vega(vl_spec, VlVersion::v5_5)
 ///     ).expect(
 ///         "Failed to perform Vega-Lite to Vega conversion"
 ///     );

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -653,7 +653,7 @@ mod tests {
         "##).unwrap();
 
         let vg_spec = ctx
-            .vegalite_to_vega(vl_spec, VlVersion::v4_17, true)
+            .vegalite_to_vega(vl_spec, VlVersion::v4_17)
             .await
             .unwrap();
         println!("vg_spec: {}", vg_spec)
@@ -674,14 +674,14 @@ mod tests {
 
         let mut ctx1 = VlConverter::new();
         let vg_spec1 = ctx1
-            .vegalite_to_vega(vl_spec.clone(), VlVersion::v4_17, true)
+            .vegalite_to_vega(vl_spec.clone(), VlVersion::v4_17)
             .await
             .unwrap();
         println!("vg_spec1: {}", vg_spec1);
 
         let mut ctx1 = VlConverter::new();
         let vg_spec2 = ctx1
-            .vegalite_to_vega(vl_spec, VlVersion::v5_5, true)
+            .vegalite_to_vega(vl_spec, VlVersion::v5_5)
             .await
             .unwrap();
         println!("vg_spec2: {}", vg_spec2);

--- a/vl-convert/Cargo.toml
+++ b/vl-convert/Cargo.toml
@@ -16,3 +16,8 @@ vl-convert-rs = {path= "../vl-convert-rs", version= "0.3.0-rc1" }
 tokio = {version="1.21.2", features=["macros", "rt-multi-thread"]}
 serde_json = "1.0.85"
 clap = {version="4.0.6", features=["derive"]}
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "2.1"
+rstest = "0.15.0"

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -242,18 +242,29 @@ async fn vl_2_vg(
     let mut converter = VlConverter::new();
 
     // Perform conversion
-    let vega_str = match converter
-        .vegalite_to_vega(vegalite_json, vl_version, pretty)
-        .await
-    {
+    let vega_json = match converter.vegalite_to_vega(vegalite_json, vl_version).await {
         Ok(vega_str) => vega_str,
         Err(err) => {
             bail!("Vega-Lite to Vega conversion failed: {}", err);
         }
     };
-
-    // Write result
-    write_output_string(output, &vega_str)?;
+    let vega_str_res = if pretty {
+        serde_json::to_string_pretty(&vega_json)
+    } else {
+        serde_json::to_string(&vega_json)
+    };
+    match vega_str_res {
+        Ok(vega_str) => {
+            // Write result
+            write_output_string(output, &vega_str)?;
+        }
+        Err(err) => {
+            bail!(
+                "Failed to serialize Vega spec to JSON string: {}",
+                err.to_string()
+            )
+        }
+    }
 
     Ok(())
 }

--- a/vl-convert/tests/test_cli.rs
+++ b/vl-convert/tests/test_cli.rs
@@ -1,0 +1,269 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::str::FromStr; // Run programs
+use std::sync::Once;
+use vl_convert_rs::VlVersion;
+
+static INIT: Once = Once::new();
+
+pub fn initialize() {
+    INIT.call_once(|| {
+        let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let outdir = root_path.join("tests").join("output");
+        fs::remove_dir_all(&outdir).ok();
+        fs::create_dir_all(&outdir).unwrap();
+    });
+}
+
+fn vl_spec_path(name: &str) -> String {
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let spec_path = root_path
+        .join("..")
+        .join("vl-convert-rs")
+        .join("tests")
+        .join("vl-specs")
+        .join(format!("{}.vl.json", name));
+    spec_path.to_str().unwrap().to_string()
+}
+
+fn load_expected_vg_spec(name: &str, vl_version: &str, pretty: bool) -> Option<String> {
+    let vl_version = VlVersion::from_str(vl_version).unwrap();
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let spec_path = root_path
+        .join("..")
+        .join("vl-convert-rs")
+        .join("tests")
+        .join("vl-specs")
+        .join("expected")
+        .join(&format!("{:?}", vl_version))
+        .join(if pretty {
+            format!("{}.vg.pretty.json", name)
+        } else {
+            format!("{}.vg.json", name)
+        });
+
+    if spec_path.exists() {
+        let spec_str = fs::read_to_string(&spec_path)
+            .unwrap_or_else(|_| panic!("Failed to read {:?}", spec_path));
+        Some(spec_str)
+    } else {
+        None
+    }
+}
+
+fn load_expected_svg(name: &str, vl_version: &str) -> String {
+    let vl_version = VlVersion::from_str(vl_version).unwrap();
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let spec_path = root_path
+        .join("..")
+        .join("vl-convert-rs")
+        .join("tests")
+        .join("vl-specs")
+        .join("expected")
+        .join(&format!("{:?}", vl_version))
+        .join(format!("{}.svg", name));
+
+    fs::read_to_string(&spec_path).unwrap()
+}
+
+fn load_expected_png(name: &str, vl_version: &str) -> Vec<u8> {
+    let vl_version = VlVersion::from_str(vl_version).unwrap();
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let spec_path = root_path
+        .join("..")
+        .join("vl-convert-rs")
+        .join("tests")
+        .join("vl-specs")
+        .join("expected")
+        .join(&format!("{:?}", vl_version))
+        .join(format!("{}.png", name));
+    let png_data =
+        fs::read(&spec_path).unwrap_or_else(|_| panic!("Failed to read {:?}", spec_path));
+    png_data
+}
+
+fn output_path(filename: &str) -> String {
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    root_path
+        .join("tests")
+        .join("output")
+        .join(filename)
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn test_font_dir() -> String {
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let fonts_dir = root_path
+        .join("..")
+        .join("vl-convert-rs")
+        .join("tests")
+        .join("fonts");
+    fonts_dir.to_str().unwrap().to_string()
+}
+
+#[test]
+fn check_no_command() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let mut cmd = Command::cargo_bin("vl-convert")?;
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage: vl-convert <COMMAND>"));
+    Ok(())
+}
+
+#[rustfmt::skip]
+mod test_vl2vg {
+    use std::fs;
+    use std::process::Command;
+    use crate::*;
+
+    #[rstest]
+    fn test(
+        #[values(
+            "4.17",
+            "5_0",
+            "v5.1",
+            "v5_2",
+            "v5_3",
+            "v5_4",
+            "v5_5",
+        )]
+        vl_version: &str,
+
+        #[values("circle_binned", "seattle-weather", "stacked_bar_h")]
+        name: &str,
+
+        #[values(true, false)]
+        pretty: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        initialize();
+
+        let output_filename = if pretty {
+            format!("{}_{}.pretty.vg.json", vl_version, name)
+        } else {
+            format!("{}_{}.vg.json", vl_version, name)
+        };
+
+        let vl_path = vl_spec_path(name);
+        let output = output_path(&output_filename);
+
+        let mut cmd = Command::cargo_bin("vl-convert")?;
+        let mut cmd = cmd.arg("vl2vg")
+            .arg("-i").arg(vl_path)
+            .arg("-o").arg(&output)
+            .arg("--vl-version").arg(vl_version);
+
+        if pretty {
+            cmd = cmd.arg("--pretty")
+        }
+
+        // Load expected
+        match load_expected_vg_spec(name, vl_version, pretty) {
+            Some(expected_str) => {
+                cmd.assert().success();
+
+                // Load written spec
+                let output_str = fs::read_to_string(&output).unwrap();
+
+                assert_eq!(expected_str, output_str)
+            }
+            None => {
+                cmd.assert().failure();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[rustfmt::skip]
+mod test_vl2svg {
+    use std::fs;
+    use std::process::Command;
+    use crate::*;
+
+    #[rstest]
+    fn test(
+        #[values(
+            "v5_5",
+        )]
+        vl_version: &str,
+
+        #[values("circle_binned", "stacked_bar_h")]
+        name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        initialize();
+
+        let output_filename = format!("{}_{}.svg", vl_version, name);
+
+        let vl_path = vl_spec_path(name);
+        let output = output_path(&output_filename);
+
+        let mut cmd = Command::cargo_bin("vl-convert")?;
+        let cmd = cmd.arg("vl2svg")
+            .arg("-i").arg(vl_path)
+            .arg("-o").arg(&output)
+            .arg("--vl-version").arg(vl_version)
+            .arg("--font-dir").arg(test_font_dir());
+
+        // Load expected
+        let expected_str = load_expected_svg(name, vl_version);
+        cmd.assert().success();
+
+        // Load written spec
+        let output_str = fs::read_to_string(&output).unwrap();
+        assert_eq!(expected_str, output_str);
+
+        Ok(())
+    }
+}
+
+#[rustfmt::skip]
+mod test_vl2png {
+    use std::fs;
+    use std::process::Command;
+    use crate::*;
+
+    #[rstest(name, scale,
+        case("circle_binned", 1.0),
+        case("stacked_bar_h", 2.0)
+    )]
+    fn test(
+        name: &str,
+        scale: f32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        initialize();
+
+        let vl_version = "5_5";
+        let output_filename = format!("{}_{}.png", vl_version, name);
+
+        let vl_path = vl_spec_path(name);
+        let output = output_path(&output_filename);
+
+        let mut cmd = Command::cargo_bin("vl-convert")?;
+        let cmd = cmd.arg("vl2png")
+            .arg("-i").arg(vl_path)
+            .arg("-o").arg(&output)
+            .arg("--vl-version").arg(vl_version)
+            .arg("--font-dir").arg(test_font_dir())
+            .arg("--scale").arg(scale.to_string());
+
+        // Load expected
+        let expected_str = load_expected_png(name, vl_version);
+        cmd.assert().success();
+
+        // Load written spec
+        let output_str = fs::read(&output).unwrap();
+        assert_eq!(expected_str, output_str);
+
+        Ok(())
+    }
+}

--- a/vl-convert/tests/test_cli.rs
+++ b/vl-convert/tests/test_cli.rs
@@ -115,7 +115,7 @@ fn check_no_command() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("Usage: vl-convert <COMMAND>"));
+        .stderr(predicate::str::contains("Usage: vl-convert"));
     Ok(())
 }
 


### PR DESCRIPTION
The main purpose of this PR is to remove as many JSON string (de)serializations steps as possible.

To this end:
 - specifications are no longer serialized to strings when passed into the Deno runtime. Instead they are converted from `serde_json::Value` directly to JavaScript objects.
 - Vega specification are no longer converted to strings when returned from the Deno runtime, instead they are returned as serde objects.
 - The Python `vega*_to_*` functions now accept either strings or Python dictionaries
 - The Python `vegalite_to_vega` function now returns a Python dict rather than a JSON string.

Additionally, I added an integration test suite for the `vl-convert` CLI application