### PR TITLE
Trim whitespace before checking for empty string in text width logic

### DIFF
--- a/vl-convert-rs/src/text.rs
+++ b/vl-convert-rs/src/text.rs
@@ -164,7 +164,7 @@ pub fn op_text_width(text_info_str: String) -> Result<f64, AnyError> {
     };
 
     if let Some(text) = text_info.text.as_str() {
-        if text.is_empty() {
+        if text.trim().is_empty() {
             return Ok(0.0);
         }
     }


### PR DESCRIPTION
Fix for https://altair-viz.github.io/gallery/multiline_tooltip.html.

The error occurred when measuring the width of non-empty whitespace