### PR TITLE
feat: Add get_local_tz function

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -392,7 +392,7 @@ vegaToSvg(
 
     pub async fn get_local_tz(&mut self) -> Result<String, AnyError> {
         let code = "var localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;";
-        self.worker.execute_script("<anon>", &code)?;
+        self.worker.execute_script("<anon>", code)?;
         self.worker.run_event_loop(false).await?;
 
         let value = self.execute_script_to_string("localTz").await?;

--- a/vl-convert-vendor/src/main.rs
+++ b/vl-convert-vendor/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
         VEGA_PATH = VEGA_PATH
     )
     .unwrap();
-    fs::write(&importsjs_path, imports).expect("Failed to write vendor_imports.js");
+    fs::write(importsjs_path, imports).expect("Failed to write vendor_imports.js");
 
     // Use deno vendor to download vega-lite and dependencies to the vendor directory
     if let Err(err) = Command::new("deno")
@@ -87,7 +87,7 @@ fn main() {
     // Load vendored import_map
     let import_map_path = vendor_path.join("import_map.json");
     let import_map_str =
-        fs::read_to_string(&import_map_path).expect("Unable to read import_map.json file");
+        fs::read_to_string(import_map_path).expect("Unable to read import_map.json file");
 
     let import_map: serde_json::Value =
         serde_json::from_str(&import_map_str).expect("Unable to parse import_map.json file");

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -188,7 +188,7 @@ fn parse_vl_version(vl_version: &str) -> Result<VlVersion, anyhow::Error> {
 }
 
 fn read_input_string(input: &str) -> Result<String, anyhow::Error> {
-    match std::fs::read_to_string(&input) {
+    match std::fs::read_to_string(input) {
         Ok(input_str) => Ok(input_str),
         Err(err) => {
             bail!("Failed to read input file: {}\n{}", input, err);
@@ -206,7 +206,7 @@ fn parse_as_json(input_str: &str) -> Result<serde_json::Value, anyhow::Error> {
 }
 
 fn write_output_string(output: &str, output_str: &str) -> Result<(), anyhow::Error> {
-    match std::fs::write(&output, output_str) {
+    match std::fs::write(output, output_str) {
         Ok(_) => Ok(()),
         Err(err) => {
             bail!("Failed to write converted output to {}\n{}", output, err);
@@ -215,7 +215,7 @@ fn write_output_string(output: &str, output_str: &str) -> Result<(), anyhow::Err
 }
 
 fn write_output_binary(output: &str, output_data: &[u8]) -> Result<(), anyhow::Error> {
-    match std::fs::write(&output, output_data) {
+    match std::fs::write(output, output_data) {
         Ok(_) => Ok(()),
         Err(err) => {
             bail!("Failed to write converted output to {}\n{}", output, err);


### PR DESCRIPTION
Add a `get_local_tz` function to the Rust and Python API that returns the named timezone of the Deno runtime (which Vega is inherently using for timezone math).