### PR TITLE
Make get_local_tz fallible, returing Option<String> instead of String

### DIFF
--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -243,10 +243,11 @@ fn register_font_directory(font_dir: &str) -> PyResult<()> {
 /// Get the named local timezone that Vega uses to perform timezone calculations
 ///
 /// Returns:
-///     str: Named local timezone (e.g. "America/New_York")
+///     str: Named local timezone (e.g. "America/New_York"),
+///          or None if the local timezone cannot be determined
 #[pyfunction]
 #[pyo3(text_signature = "()")]
-fn get_local_tz() -> PyResult<String> {
+fn get_local_tz() -> PyResult<Option<String>> {
     let mut converter = VL_CONVERTER
         .lock()
         .expect("Failed to acquire lock on Vega-Lite converter");

--- a/vl-convert-python/tests/test_get_local_tz.py
+++ b/vl-convert-python/tests/test_get_local_tz.py
@@ -1,0 +1,7 @@
+import vl_convert as vlc
+
+
+def test_get_local_tz_is_str_or_none():
+    # Just check that get_local_tz runs and returns a string or None
+    local_tz = vlc.get_local_tz()
+    assert isinstance(local_tz, str) or local_tz is None


### PR DESCRIPTION
This is to handle the case where `Intl.DateTimeFormat().resolvedOptions().timeZone` is `undefined` in Deno.

I ran into this running VlConvert on Binder, where `Intl.DateTimeFormat().resolvedOptions().timeZone` is undefined and this caused get_local_tz to crash.