### PR TITLE
Check for theme in usermeta.embedOptions.theme

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -191,8 +191,10 @@ function compileVegaLite_{ver_name}(vlSpec, config, theme) {{
     let options = {{}};
 
     // Handle config and theme
-    if (theme != null) {{
-        options["config"] = vega.mergeConfig(vegaThemes[theme], config ?? {{}});
+    let usermetaTheme = ((vlSpec.usermeta ?? {{}}).embedOptions ?? {{}}).theme;
+    let namedTheme = theme ?? usermetaTheme;
+    if (namedTheme != null) {{
+        options["config"] = vega.mergeConfig(vegaThemes[namedTheme], config ?? {{}});
     }} else if (config != null) {{
         options["config"] = config;
     }}
@@ -204,8 +206,10 @@ function vegaLiteToSvg_{ver_name}(vlSpec, config, theme) {{
     let options = {{}};
 
     // Handle config and theme
-    if (theme != null) {{
-        options["config"] = vega.mergeConfig(vegaThemes[theme], config ?? {{}});
+    let usermetaTheme = ((vlSpec.usermeta ?? {{}}).embedOptions ?? {{}}).theme;
+    let namedTheme = theme ?? usermetaTheme;
+    if (namedTheme != null) {{
+        options["config"] = vega.mergeConfig(vegaThemes[namedTheme], config ?? {{}});
     }} else if (config != null) {{
         options["config"] = config;
     }}


### PR DESCRIPTION
This PR updates the `VlConverter` to check Vega-Lite specs for a named theme specified in `usermeta.embedOptions.theme`. This is what vega-embed does, and this is where Altair places it's named theme.

This will make named these work with Altair without any Altair changes.

See background in https://github.com/altair-viz/altair/issues/781