### PR TITLE
Fix "from_rgba returned None" panic

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -863,7 +863,8 @@ pub fn encode_png(pixmap: Pixmap, ppi: f32) -> Result<Vec<u8>, AnyError> {
         let alpha = c.alpha();
 
         // jonmmease: tiny-skia uses the private PremultipliedColorU8::from_rgba_unchecked here,
-        // but all this method does is construct a `PremultipliedColorU8` from components.
+        // but we need to use from_rgba, which checks to make sure r/g/b are less then or equal
+        // to alpha. Use min to ensure we don't trigger the check
         *pixel = PremultipliedColorU8::from_rgba(
             c.red().min(alpha),
             c.green().min(alpha),

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -860,10 +860,16 @@ pub fn encode_png(pixmap: Pixmap, ppi: f32) -> Result<Vec<u8>, AnyError> {
     // due to rounding. So we stick with this method for now.
     for pixel in pixmap.pixels_mut() {
         let c = pixel.demultiply();
+        let alpha = c.alpha();
 
         // jonmmease: tiny-skia uses the private PremultipliedColorU8::from_rgba_unchecked here,
         // but all this method does is construct a `PremultipliedColorU8` from components.
-        *pixel = PremultipliedColorU8([c.red(), c.green(), c.blue(), c.alpha()]);
+        *pixel = PremultipliedColorU8::from_rgba(
+            c.red().min(alpha),
+            c.green().min(alpha),
+            c.blue().min(alpha),
+            alpha,
+        ).expect("Failed to construct PremultipliedColorU8 from rgba");
     }
 
     let mut data = Vec::new();

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -869,7 +869,8 @@ pub fn encode_png(pixmap: Pixmap, ppi: f32) -> Result<Vec<u8>, AnyError> {
             c.green().min(alpha),
             c.blue().min(alpha),
             alpha,
-        ).expect("Failed to construct PremultipliedColorU8 from rgba");
+        )
+        .expect("Failed to construct PremultipliedColorU8 from rgba");
     }
 
     let mut data = Vec::new();

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -860,8 +860,10 @@ pub fn encode_png(pixmap: Pixmap, ppi: f32) -> Result<Vec<u8>, AnyError> {
     // due to rounding. So we stick with this method for now.
     for pixel in pixmap.pixels_mut() {
         let c = pixel.demultiply();
-        *pixel = PremultipliedColorU8::from_rgba(c.red(), c.green(), c.blue(), c.alpha())
-            .expect("from_rgba returned None");
+
+        // jonmmease: tiny-skia uses the private PremultipliedColorU8::from_rgba_unchecked here,
+        // but all this method does is construct a `PremultipliedColorU8` from components.
+        *pixel = PremultipliedColorU8([c.red(), c.green(), c.blue(), c.alpha()]);
     }
 
     let mut data = Vec::new();


### PR DESCRIPTION
Closes #94 

In 0.13.0, the `encode_png` function was copied from tiny-skia and modified to support the `ppi`. The tiny-skia version is here:

https://github.com/RazrFalcon/tiny-skia/blob/d2b7abbde312a18f4c62ddc7201a32eb6e1a146f/src/pixmap.rs#L390-L419

This version uses the private `PremultipliedColorU8::from_rgba_unchecked` function to build pixels. I swapped this for the public `PremultipliedColorU8::from_rgba` function, which returns an Option that I unwraped. But it turns out the checked part is triggered for some pixels for the images in the VegaFusion test suite. This PR uses `min` to clamp the rgb values to the alpha value (which is what `from_rgba` checks).

