### PR TITLE
Add option to control whether to display Vega-Lite compiler warnings

### DIFF
--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -31,15 +31,17 @@ lazy_static! {
 ///         (default to latest)
 ///     config (dict | None): Chart configuration object to apply during conversion
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
+///     show_warnings (bool | None): Whether to print Vega-Lite compilation warnings (default false)
 /// Returns:
 ///     dict: Vega JSON specification dict
 #[pyfunction]
-#[pyo3(text_signature = "(vl_spec, vl_version, config, theme)")]
+#[pyo3(text_signature = "(vl_spec, vl_version, config, theme, show_warnings)")]
 fn vegalite_to_vega(
     vl_spec: PyObject,
     vl_version: Option<&str>,
     config: Option<PyObject>,
     theme: Option<String>,
+    show_warnings: Option<bool>,
 ) -> PyResult<PyObject> {
     let vl_spec = parse_json_spec(vl_spec)?;
     let config = config.and_then(|c| parse_json_spec(c).ok());
@@ -59,6 +61,7 @@ fn vegalite_to_vega(
             vl_version,
             config,
             theme,
+            show_warnings: show_warnings.unwrap_or(false),
         },
     )) {
         Ok(vega_spec) => vega_spec,
@@ -111,15 +114,17 @@ fn vega_to_svg(vg_spec: PyObject) -> PyResult<String> {
 ///         (default to latest)
 ///     config (dict | None): Chart configuration object to apply during conversion
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
+///     show_warnings (bool | None): Whether to print Vega-Lite compilation warnings (default false)
 /// Returns:
 ///     str: SVG image string
 #[pyfunction]
-#[pyo3(text_signature = "(vl_spec, vl_version, config, theme)")]
+#[pyo3(text_signature = "(vl_spec, vl_version, config, theme, show_warnings)")]
 fn vegalite_to_svg(
     vl_spec: PyObject,
     vl_version: Option<&str>,
     config: Option<PyObject>,
     theme: Option<String>,
+    show_warnings: Option<bool>,
 ) -> PyResult<String> {
     let vl_spec = parse_json_spec(vl_spec)?;
     let config = config.and_then(|c| parse_json_spec(c).ok());
@@ -140,6 +145,7 @@ fn vegalite_to_svg(
             vl_version,
             config,
             theme,
+            show_warnings: show_warnings.unwrap_or(false),
         },
     )) {
         Ok(vega_spec) => vega_spec,
@@ -197,11 +203,11 @@ fn vega_to_png(vg_spec: PyObject, scale: Option<f32>, ppi: Option<f32>) -> PyRes
 ///     ppi (float): Pixels per inch (default 72)
 ///     config (dict | None): Chart configuration object to apply during conversion
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
-///
+///     show_warnings (bool | None): Whether to print Vega-Lite compilation warnings (default false)
 /// Returns:
 ///     bytes: PNG image data
 #[pyfunction]
-#[pyo3(text_signature = "(vl_spec, vl_version, scale, ppi, config, theme)")]
+#[pyo3(text_signature = "(vl_spec, vl_version, scale, ppi, config, theme, show_warnings)")]
 fn vegalite_to_png(
     vl_spec: PyObject,
     vl_version: Option<&str>,
@@ -209,6 +215,7 @@ fn vegalite_to_png(
     ppi: Option<f32>,
     config: Option<PyObject>,
     theme: Option<String>,
+    show_warnings: Option<bool>,
 ) -> PyResult<PyObject> {
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
@@ -228,6 +235,7 @@ fn vegalite_to_png(
             vl_version,
             config,
             theme,
+            show_warnings: show_warnings.unwrap_or(false),
         },
         scale,
         ppi,
@@ -290,11 +298,11 @@ fn vega_to_jpeg(vg_spec: PyObject, scale: Option<f32>, quality: Option<u8>) -> P
 ///     quality (int): JPEG Quality between 0 (worst) and 100 (best). Default 90
 ///     config (dict | None): Chart configuration object to apply during conversion
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
-///
+///     show_warnings (bool | None): Whether to print Vega-Lite compilation warnings (default false)
 /// Returns:
 ///     bytes: JPEG image data
 #[pyfunction]
-#[pyo3(text_signature = "(vl_spec, vl_version, scale, quality, config, theme)")]
+#[pyo3(text_signature = "(vl_spec, vl_version, scale, quality, config, theme, show_warnings)")]
 fn vegalite_to_jpeg(
     vl_spec: PyObject,
     vl_version: Option<&str>,
@@ -302,6 +310,7 @@ fn vegalite_to_jpeg(
     quality: Option<u8>,
     config: Option<PyObject>,
     theme: Option<String>,
+    show_warnings: Option<bool>,
 ) -> PyResult<PyObject> {
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
@@ -321,6 +330,7 @@ fn vegalite_to_jpeg(
             vl_version,
             config,
             theme,
+            show_warnings: show_warnings.unwrap_or(false),
         },
         scale,
         quality,

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -393,6 +393,7 @@ mod test_png_theme_config {
                     vl_version,
                     theme: Some(theme.to_string()),
                     config: Some(json!({"background": BACKGROUND_COLOR})),
+                    show_warnings: false
                 },
                 Some(scale),
                 None
@@ -415,6 +416,7 @@ mod test_png_theme_config {
                     vl_version,
                     theme: None,
                     config: Some(json!({"background": BACKGROUND_COLOR})),
+                    show_warnings: false
                 },
                 Some(scale),
                 None

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -50,7 +50,7 @@ enum Commands {
         pretty: bool,
 
         /// Whether to show Vega-Lite compilation warnings
-        #[arg(short, long)]
+        #[arg(long)]
         show_warnings: bool,
     },
 
@@ -78,7 +78,7 @@ enum Commands {
         config: Option<String>,
 
         /// Whether to show Vega-Lite compilation warnings
-        #[arg(short, long)]
+        #[arg(long)]
         show_warnings: bool,
 
         /// Additional directory to search for fonts
@@ -110,7 +110,7 @@ enum Commands {
         config: Option<String>,
 
         /// Image scale factor
-        #[arg(short, long, default_value = "1.0")]
+        #[arg(long, default_value = "1.0")]
         scale: f32,
 
         /// Pixels per inch
@@ -118,7 +118,7 @@ enum Commands {
         ppi: f32,
 
         /// Whether to show Vega-Lite compilation warnings
-        #[arg(short, long)]
+        #[arg(long)]
         show_warnings: bool,
 
         /// Additional directory to search for fonts
@@ -150,7 +150,7 @@ enum Commands {
         config: Option<String>,
 
         /// Image scale factor
-        #[arg(short, long, default_value = "1.0")]
+        #[arg(long, default_value = "1.0")]
         scale: f32,
 
         /// JPEG Quality between 0 (worst) and 100 (best)
@@ -194,7 +194,7 @@ enum Commands {
         output: String,
 
         /// Image scale factor
-        #[arg(short, long, default_value = "1.0")]
+        #[arg(long, default_value = "1.0")]
         scale: f32,
 
         /// Pixels per inch
@@ -218,7 +218,7 @@ enum Commands {
         output: String,
 
         /// Image scale factor
-        #[arg(short, long, default_value = "1.0")]
+        #[arg(long, default_value = "1.0")]
         scale: f32,
 
         /// JPEG Quality between 0 (worst) and 100 (best)

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -290,7 +290,17 @@ async fn main() -> Result<(), anyhow::Error> {
             font_dir,
         } => {
             register_font_dir(font_dir)?;
-            vl_2_png(&input, &output, &vl_version, theme, config, scale, ppi, show_warnings).await?
+            vl_2_png(
+                &input,
+                &output,
+                &vl_version,
+                theme,
+                config,
+                scale,
+                ppi,
+                show_warnings,
+            )
+            .await?
         }
         Vl2jpeg {
             input,
@@ -304,7 +314,17 @@ async fn main() -> Result<(), anyhow::Error> {
             font_dir,
         } => {
             register_font_dir(font_dir)?;
-            vl_2_jpeg(&input, &output, &vl_version, theme, config, scale, quality, show_warnings).await?
+            vl_2_jpeg(
+                &input,
+                &output,
+                &vl_version,
+                theme,
+                config,
+                scale,
+                quality,
+                show_warnings,
+            )
+            .await?
         }
         Vg2svg {
             input,

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
         /// Pretty-print JSON in output file
         #[arg(short, long)]
         pretty: bool,
+
+        /// Whether to show Vega-Lite compilation warnings
+        #[arg(short, long)]
+        show_warnings: bool,
     },
 
     /// Convert a Vega-Lite specification to an SVG image
@@ -72,6 +76,10 @@ enum Commands {
         /// Path to Vega-Lite config file. Defaults to ~/.config/vl-convert/config.json
         #[arg(short, long)]
         config: Option<String>,
+
+        /// Whether to show Vega-Lite compilation warnings
+        #[arg(short, long)]
+        show_warnings: bool,
 
         /// Additional directory to search for fonts
         #[arg(long)]
@@ -109,6 +117,10 @@ enum Commands {
         #[arg(short, long, default_value = "72.0")]
         ppi: f32,
 
+        /// Whether to show Vega-Lite compilation warnings
+        #[arg(short, long)]
+        show_warnings: bool,
+
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
@@ -144,6 +156,10 @@ enum Commands {
         /// JPEG Quality between 0 (worst) and 100 (best)
         #[arg(short, long, default_value = "90")]
         quality: u8,
+
+        /// Whether to show Vega-Lite compilation warnings
+        #[arg(short, long)]
+        show_warnings: bool,
 
         /// Additional directory to search for fonts
         #[arg(long)]
@@ -237,6 +253,7 @@ async fn main() -> Result<(), anyhow::Error> {
             theme,
             config,
             pretty,
+            show_warnings,
         } => {
             vl_2_vg(
                 &input_vegalite_file,
@@ -245,6 +262,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 theme,
                 config,
                 pretty,
+                show_warnings,
             )
             .await?
         }
@@ -254,10 +272,11 @@ async fn main() -> Result<(), anyhow::Error> {
             vl_version,
             theme,
             config,
+            show_warnings,
             font_dir,
         } => {
             register_font_dir(font_dir)?;
-            vl_2_svg(&input, &output, &vl_version, theme, config).await?
+            vl_2_svg(&input, &output, &vl_version, theme, config, show_warnings).await?
         }
         Vl2png {
             input,
@@ -267,10 +286,11 @@ async fn main() -> Result<(), anyhow::Error> {
             config,
             scale,
             ppi,
+            show_warnings,
             font_dir,
         } => {
             register_font_dir(font_dir)?;
-            vl_2_png(&input, &output, &vl_version, theme, config, scale, ppi).await?
+            vl_2_png(&input, &output, &vl_version, theme, config, scale, ppi, show_warnings).await?
         }
         Vl2jpeg {
             input,
@@ -280,10 +300,11 @@ async fn main() -> Result<(), anyhow::Error> {
             config,
             scale,
             quality,
+            show_warnings,
             font_dir,
         } => {
             register_font_dir(font_dir)?;
-            vl_2_jpeg(&input, &output, &vl_version, theme, config, scale, quality).await?
+            vl_2_jpeg(&input, &output, &vl_version, theme, config, scale, quality, show_warnings).await?
         }
         Vg2svg {
             input,
@@ -409,6 +430,7 @@ async fn vl_2_vg(
     theme: Option<String>,
     config: Option<String>,
     pretty: bool,
+    show_warnings: bool,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -433,6 +455,7 @@ async fn vl_2_vg(
                 vl_version,
                 theme,
                 config,
+                show_warnings,
             },
         )
         .await
@@ -549,6 +572,7 @@ async fn vl_2_svg(
     vl_version: &str,
     theme: Option<String>,
     config: Option<String>,
+    show_warnings: bool,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -573,6 +597,7 @@ async fn vl_2_svg(
                 vl_version,
                 config,
                 theme,
+                show_warnings,
             },
         )
         .await
@@ -597,6 +622,7 @@ async fn vl_2_png(
     config: Option<String>,
     scale: f32,
     ppi: f32,
+    show_warnings: bool,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -621,6 +647,7 @@ async fn vl_2_png(
                 vl_version,
                 config,
                 theme,
+                show_warnings,
             },
             Some(scale),
             Some(ppi),
@@ -647,6 +674,7 @@ async fn vl_2_jpeg(
     config: Option<String>,
     scale: f32,
     quality: u8,
+    show_warnings: bool,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -671,6 +699,7 @@ async fn vl_2_jpeg(
                 vl_version,
                 config,
                 theme,
+                show_warnings,
             },
             Some(scale),
             Some(quality),

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -634,6 +634,7 @@ async fn vl_2_svg(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn vl_2_png(
     input: &str,
     output: &str,
@@ -686,6 +687,7 @@ async fn vl_2_png(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn vl_2_jpeg(
     input: &str,
     output: &str,


### PR DESCRIPTION
Adds a `show_warnings` option to the Rust, Python, and CLI interfaces to control whether Vega-Lite compiler warnings should be printed.

Previously, these were always printed. Now they are not printed by default and can be enabled using the `show_warnings` argument.

See https://github.com/altair-viz/altair/issues/3138 for some discussion of hiding these warnings

cc @joelostblom