### PR TITLE
Add support for converting SVG images to PNG, JPEG, and PDF

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,9 +113,10 @@ jobs:
         run: |
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Run tests
+        # Run tests on single thread for Deno, which expects this
+        run: |
+          cargo test -- --test-threads=1
       - name: Upload test failures
         uses: actions/upload-artifact@v2
         if: always()

--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@ Commands:
   vl2png     Convert a Vega-Lite specification to an PNG image
   vl2jpeg    Convert a Vega-Lite specification to an JPEG image
   vl2pdf     Convert a Vega-Lite specification to a PDF image
+  vl2url     Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
   vg2svg     Convert a Vega specification to an SVG image
   vg2png     Convert a Vega specification to an PNG image
   vg2jpeg    Convert a Vega specification to an JPEG image
   vg2pdf     Convert a Vega specification to an PDF image
+  vg2url     Convert a Vega specification to a URL that opens the chart in the Vega editor
+  svg2png    Convert an SVG image to a PNG image
+  svg2jpeg   Convert an SVG image to a JPEG image
+  svg2pdf    Convert an SVG image to a PDF image
   ls-themes  List available themes
   cat-theme  Print the config JSON for a theme
   help       Print this message or the help of the given subcommand(s)

--- a/vl-convert-pdf/examples/pdf_conversion.rs
+++ b/vl-convert-pdf/examples/pdf_conversion.rs
@@ -17,5 +17,5 @@ fn main() {
     font_db.load_system_fonts();
 
     let pdf_bytes = svg_to_pdf(&tree, &font_db, 1.0).unwrap();
-    fs::write("target/hello.pdf".to_string(), pdf_bytes).unwrap();
+    fs::write("target/hello.pdf", pdf_bytes).unwrap();
 }

--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -392,7 +392,7 @@ fn vega_to_pdf(vg_spec: PyObject, scale: Option<f32>) -> PyResult<PyObject> {
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
 ///
 /// Returns:
-///     bytes: JPEG image data
+///     bytes: PDF image data
 #[pyfunction]
 #[pyo3(text_signature = "(vl_spec, vl_version, scale, config, theme)")]
 fn vegalite_to_pdf(
@@ -471,6 +471,56 @@ fn vega_to_url(vg_spec: PyObject, fullscreen: Option<bool>) -> PyResult<String> 
         &vg_spec,
         fullscreen.unwrap_or(false),
     )?)
+}
+
+/// Convert an SVG image string to PNG image data
+///
+/// Args:
+///     svg (str): SVG image string
+///     scale (float): Image scale factor (default 1.0)
+///     ppi (float): Pixels per inch (default 72)
+/// Returns:
+///     bytes: PNG image data
+#[pyfunction]
+#[pyo3(text_signature = "(svg, scale, ppi)")]
+fn svg_to_png(svg: &str, scale: Option<f32>, ppi: Option<f32>) -> PyResult<PyObject> {
+    let png_data = vl_convert_rs::converter::svg_to_png(svg, scale.unwrap_or(1.0), ppi)?;
+    Ok(Python::with_gil(|py| -> PyObject {
+        PyObject::from(PyBytes::new(py, png_data.as_slice()))
+    }))
+}
+
+/// Convert an SVG image string to JPEG image data
+///
+/// Args:
+///     svg (str): SVG image string
+///     scale (float): Image scale factor (default 1.0)
+///     quality (int): JPEG Quality between 0 (worst) and 100 (best). Default 90
+/// Returns:
+///     bytes: JPEG image data
+#[pyfunction]
+#[pyo3(text_signature = "(svg, scale, quality)")]
+fn svg_to_jpeg(svg: &str, scale: Option<f32>, quality: Option<u8>) -> PyResult<PyObject> {
+    let jpeg_data = vl_convert_rs::converter::svg_to_jpeg(svg, scale.unwrap_or(1.0), quality)?;
+    Ok(Python::with_gil(|py| -> PyObject {
+        PyObject::from(PyBytes::new(py, jpeg_data.as_slice()))
+    }))
+}
+
+/// Convert an SVG image string to PDF document data
+///
+/// Args:
+///     svg (str): SVG image string
+///     scale (float): Image scale factor (default 1.0)
+/// Returns:
+///     bytes: PDF document data
+#[pyfunction]
+#[pyo3(text_signature = "(svg, scale)")]
+fn svg_to_pdf(svg: &str, scale: Option<f32>) -> PyResult<PyObject> {
+    let pdf_data = vl_convert_rs::converter::svg_to_pdf(svg, scale.unwrap_or(1.0))?;
+    Ok(Python::with_gil(|py| -> PyObject {
+        PyObject::from(PyBytes::new(py, pdf_data.as_slice()))
+    }))
 }
 
 /// Helper function to parse an input Python string or dict as a serde_json::Value
@@ -575,6 +625,9 @@ fn vl_convert(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(vega_to_jpeg, m)?)?;
     m.add_function(wrap_pyfunction!(vega_to_pdf, m)?)?;
     m.add_function(wrap_pyfunction!(vega_to_url, m)?)?;
+    m.add_function(wrap_pyfunction!(svg_to_png, m)?)?;
+    m.add_function(wrap_pyfunction!(svg_to_jpeg, m)?)?;
+    m.add_function(wrap_pyfunction!(svg_to_pdf, m)?)?;
     m.add_function(wrap_pyfunction!(register_font_directory, m)?)?;
     m.add_function(wrap_pyfunction!(get_local_tz, m)?)?;
     m.add_function(wrap_pyfunction!(get_themes, m)?)?;

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -908,7 +908,7 @@ pub fn svg_to_png(svg: &str, scale: f32, ppi: Option<f32>) -> Result<Vec<u8>, An
     // catch_unwind so that we don't poison Mutexes
     // if usvg/resvg panics
     let response = panic::catch_unwind(|| {
-        let mut rtree = match parse_svg(&svg) {
+        let mut rtree = match parse_svg(svg) {
             Ok(rtree) => rtree,
             Err(err) => return Err(err),
         };
@@ -959,7 +959,7 @@ pub fn svg_to_pdf(svg: &str, scale: f32) -> Result<Vec<u8>, AnyError> {
         .lock()
         .map_err(|err| anyhow!("Failed to acquire fontdb lock: {}", err.to_string()))?;
 
-    let tree = parse_svg(&svg)?;
+    let tree = parse_svg(svg)?;
     vl_convert_pdf::svg_to_pdf(&tree, &font_db, scale)
 }
 

--- a/vl-convert/README.md
+++ b/vl-convert/README.md
@@ -28,6 +28,9 @@ Commands:
   vg2jpeg    Convert a Vega specification to an JPEG image
   vg2pdf     Convert a Vega specification to an PDF image
   vg2url     Convert a Vega specification to a URL that opens the chart in the Vega editor
+  svg2png    Convert an SVG image to a PNG image
+  svg2jpeg   Convert an SVG image to a JPEG image
+  svg2pdf    Convert an SVG image to a PDF image
   ls-themes  List available themes
   cat-theme  Print the config JSON for a theme
   help       Print this message or the help of the given subcommand(s)
@@ -230,6 +233,54 @@ Options:
   -i, --input <INPUT>  Path to input Vega file
       --fullscreen     Open chart in fullscreen mode
   -h, --help           Print help
+```
+
+### svg2png
+Convert an SVG image to a PNG image
+
+```
+Convert an SVG image to a PNG image
+
+Usage: vl-convert svg2png [OPTIONS] --input <INPUT> --output <OUTPUT>
+
+Options:
+  -i, --input <INPUT>        Path to input SVG file
+  -o, --output <OUTPUT>      Path to output PNG file to be created
+      --scale <SCALE>        Image scale factor [default: 1.0]
+  -p, --ppi <PPI>            Pixels per inch [default: 72.0]
+      --font-dir <FONT_DIR>  Additional directory to search for fonts
+  -h, --help                 Print help
+```
+
+### svg2jpeg
+Convert an SVG image to a JPEG image
+```
+Convert an SVG image to a JPEG image
+
+Usage: vl-convert svg2jpeg [OPTIONS] --input <INPUT> --output <OUTPUT>
+
+Options:
+  -i, --input <INPUT>        Path to input SVG file
+  -o, --output <OUTPUT>      Path to output JPEG file to be created
+      --scale <SCALE>        Image scale factor [default: 1.0]
+  -q, --quality <QUALITY>    JPEG Quality between 0 (worst) and 100 (best) [default: 90]
+      --font-dir <FONT_DIR>  Additional directory to search for fonts
+  -h, --help                 Print help
+```
+
+### svg2pdf
+Convert an SVG image to a PDF image
+```
+Convert an SVG image to a PDF image
+
+Usage: vl-convert svg2pdf [OPTIONS] --input <INPUT> --output <OUTPUT>
+
+Options:
+  -i, --input <INPUT>        Path to input SVG file
+  -o, --output <OUTPUT>      Path to output PDF file to be created
+      --scale <SCALE>        Image scale factor [default: 1.0]
+      --font-dir <FONT_DIR>  Additional directory to search for fonts
+  -h, --help                 Print help
 ```
 
 ### ls-themes

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -310,6 +310,74 @@ enum Commands {
         fullscreen: bool,
     },
 
+    /// Convert an SVG image to a PNG image
+    #[command(arg_required_else_help = true)]
+    Svg2png {
+        /// Path to input SVG file
+        #[arg(short, long)]
+        input: String,
+
+        /// Path to output PNG file to be created
+        #[arg(short, long)]
+        output: String,
+
+        /// Image scale factor
+        #[arg(long, default_value = "1.0")]
+        scale: f32,
+
+        /// Pixels per inch
+        #[arg(short, long, default_value = "72.0")]
+        ppi: f32,
+
+        /// Additional directory to search for fonts
+        #[arg(long)]
+        font_dir: Option<String>,
+    },
+
+    /// Convert an SVG image to a JPEG image
+    #[command(arg_required_else_help = true)]
+    Svg2jpeg {
+        /// Path to input SVG file
+        #[arg(short, long)]
+        input: String,
+
+        /// Path to output JPEG file to be created
+        #[arg(short, long)]
+        output: String,
+
+        /// Image scale factor
+        #[arg(long, default_value = "1.0")]
+        scale: f32,
+
+        /// JPEG Quality between 0 (worst) and 100 (best)
+        #[arg(short, long, default_value = "90")]
+        quality: u8,
+
+        /// Additional directory to search for fonts
+        #[arg(long)]
+        font_dir: Option<String>,
+    },
+
+    /// Convert an SVG image to a PDF image
+    #[command(arg_required_else_help = true)]
+    Svg2pdf {
+        /// Path to input SVG file
+        #[arg(short, long)]
+        input: String,
+
+        /// Path to output PDF file to be created
+        #[arg(short, long)]
+        output: String,
+
+        /// Image scale factor
+        #[arg(long, default_value = "1.0")]
+        scale: f32,
+
+        /// Additional directory to search for fonts
+        #[arg(long)]
+        font_dir: Option<String>,
+    },
+
     /// List available themes
     LsThemes,
 
@@ -474,6 +542,41 @@ async fn main() -> Result<(), anyhow::Error> {
             let vg_str = read_input_string(&input)?;
             let vg_spec = serde_json::from_str(&vg_str)?;
             println!("{}", vega_to_url(&vg_spec, fullscreen)?)
+        }
+        Svg2png {
+            input,
+            output,
+            scale,
+            ppi,
+            font_dir,
+        } => {
+            register_font_dir(font_dir)?;
+            let svg = read_input_string(&input)?;
+            let png_data = vl_convert_rs::converter::svg_to_png(&svg, scale, Some(ppi))?;
+            write_output_binary(&output, &png_data)?;
+        }
+        Svg2jpeg {
+            input,
+            output,
+            scale,
+            quality,
+            font_dir,
+        } => {
+            register_font_dir(font_dir)?;
+            let svg = read_input_string(&input)?;
+            let jpeg_data = vl_convert_rs::converter::svg_to_jpeg(&svg, scale, Some(quality))?;
+            write_output_binary(&output, &jpeg_data)?;
+        }
+        Svg2pdf {
+            input,
+            output,
+            scale,
+            font_dir,
+        } => {
+            register_font_dir(font_dir)?;
+            let svg = read_input_string(&input)?;
+            let pdf_data = vl_convert_rs::converter::svg_to_pdf(&svg, scale)?;
+            write_output_binary(&output, &pdf_data)?;
         }
         LsThemes => list_themes().await?,
         CatTheme { theme } => cat_theme(&theme).await?,


### PR DESCRIPTION
Closes #107 by adding support for converting from SVG to PNG, JPEG, and PDF in the Python and CLI interfaces.