### PR TITLE
fix memory leak by finalizing Vega view on cleanup

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -203,7 +203,7 @@ function vegaToSvg(vgSpec) {
     const baseURL = 'https://vega.github.io/vega-datasets/';
     const loader = vega.loader({ mode: 'http', baseURL });
     let view = new vega.View(runtime, {renderer: 'none', loader});
-    let svgPromise = view.toSVG();
+    let svgPromise = view.toSVG().finally(() => { view.finalize() });
     return svgPromise
 }
 "#;


### PR DESCRIPTION
Closes https://github.com/vega/vl-convert/issues/112 by calling [`view.finalize()`](https://vega.github.io/vega/docs/api/view/#view_finalize) to clean up the Vega view. In particular, this removes event listeners, which Vega uses to implement its interactive behavior.  So it makes sense that we'd see a memory leak for interactive charts but not static charts.

With this change, memory usage stays nice and flat.

<img width="780" alt="Screenshot 2023-09-21 at 3 52 47 PM" src="https://github.com/vega/vl-convert/assets/15064365/e04245eb-6029-49f7-978b-2634a28b57a3">

Thanks for the report and repro @btabram!
