### PR TITLE
Add conversions to Vega scenegraph

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -562,7 +562,10 @@ vegaToSvg(
         Ok(value)
     }
 
-    pub async fn vega_to_scenegraph(&mut self, vg_spec: &serde_json::Value) -> Result<serde_json::Value, AnyError> {
+    pub async fn vega_to_scenegraph(
+        &mut self,
+        vg_spec: &serde_json::Value,
+    ) -> Result<serde_json::Value, AnyError> {
         self.init_vega().await?;
 
         let arg_id = set_json_arg(vg_spec.clone())?;
@@ -728,7 +731,11 @@ impl VlConverter {
                             let svg_result = inner.vegalite_to_svg(&vl_spec, vl_opts).await;
                             responder.send(svg_result).ok();
                         }
-                        VlConvertCommand::VlToSg { vl_spec, vl_opts, responder } => {
+                        VlConvertCommand::VlToSg {
+                            vl_spec,
+                            vl_opts,
+                            responder,
+                        } => {
                             let sg_result = inner.vegalite_to_scenegraph(&vl_spec, vl_opts).await;
                             responder.send(sg_result).ok();
                         }
@@ -808,7 +815,10 @@ impl VlConverter {
         }
     }
 
-    pub async fn vega_to_scenegraph(&mut self, vg_spec: serde_json::Value) -> Result<serde_json::Value, AnyError> {
+    pub async fn vega_to_scenegraph(
+        &mut self,
+        vg_spec: serde_json::Value,
+    ) -> Result<serde_json::Value, AnyError> {
         let (resp_tx, resp_rx) = oneshot::channel::<Result<serde_json::Value, AnyError>>();
         let cmd = VlConvertCommand::VgToSg {
             vg_spec,
@@ -821,7 +831,10 @@ impl VlConverter {
                 // All good
             }
             Err(err) => {
-                bail!("Failed to send Scenegraph conversion request: {}", err.to_string())
+                bail!(
+                    "Failed to send Scenegraph conversion request: {}",
+                    err.to_string()
+                )
             }
         }
 
@@ -879,7 +892,10 @@ impl VlConverter {
                 // All good
             }
             Err(err) => {
-                bail!("Failed to send Scenegraph conversion request: {}", err.to_string())
+                bail!(
+                    "Failed to send Scenegraph conversion request: {}",
+                    err.to_string()
+                )
             }
         }
 

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -101,7 +101,11 @@ fn make_expected_svg_path(name: &str, vl_version: VlVersion, theme: Option<&str>
         })
 }
 
-fn make_expected_scenegraph_path(name: &str, vl_version: VlVersion, theme: Option<&str>) -> PathBuf {
+fn make_expected_scenegraph_path(
+    name: &str,
+    vl_version: VlVersion,
+    theme: Option<&str>,
+) -> PathBuf {
     let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
     root_path
         .join("tests")
@@ -120,9 +124,15 @@ fn load_expected_svg(name: &str, vl_version: VlVersion, theme: Option<&str>) -> 
     fs::read_to_string(&spec_path).ok()
 }
 
-fn load_expected_scenegraph(name: &str, vl_version: VlVersion, theme: Option<&str>) -> Option<Value> {
+fn load_expected_scenegraph(
+    name: &str,
+    vl_version: VlVersion,
+    theme: Option<&str>,
+) -> Option<Value> {
     let spec_path = make_expected_scenegraph_path(name, vl_version, theme);
-    let Some(p) = fs::read_to_string(&spec_path).ok() else { return None };
+    let Some(p) = fs::read_to_string(&spec_path).ok() else {
+        return None;
+    };
     serde_json::from_str(&p).ok()
 }
 
@@ -147,7 +157,12 @@ fn write_failed_svg(name: &str, vl_version: VlVersion, theme: Option<&str>, img:
     return file_path;
 }
 
-fn write_failed_scenegraph(name: &str, vl_version: VlVersion, theme: Option<&str>, sg: &Value) -> PathBuf {
+fn write_failed_scenegraph(
+    name: &str,
+    vl_version: VlVersion,
+    theme: Option<&str>,
+    sg: &Value,
+) -> PathBuf {
     let root_path = Path::new(env!("CARGO_MANIFEST_DIR"));
     let failed_dir = root_path
         .join("tests")
@@ -164,7 +179,8 @@ fn write_failed_scenegraph(name: &str, vl_version: VlVersion, theme: Option<&str
     });
 
     let mut file = fs::File::create(file_path.clone()).unwrap();
-    file.write_all(serde_json::to_string_pretty(sg).unwrap().as_bytes()).unwrap();
+    file.write_all(serde_json::to_string_pretty(sg).unwrap().as_bytes())
+        .unwrap();
     return file_path;
 }
 

--- a/vl-convert-rs/tests/vl-specs/expected/v5_8/no_text_in_font_metrics.sg.json
+++ b/vl-convert-rs/tests/vl-specs/expected/v5_8/no_text_in_font_metrics.sg.json
@@ -1,0 +1,456 @@
+{
+  "marktype": "group",
+  "name": "root",
+  "role": "frame",
+  "interactive": true,
+  "clip": false,
+  "items": [
+    {
+      "items": [
+        {
+          "marktype": "group",
+          "role": "axis",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "items": [
+                {
+                  "marktype": "rule",
+                  "role": "axis-grid",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 200,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    },
+                    {
+                      "x": 0,
+                      "y": 167,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    },
+                    {
+                      "x": 0,
+                      "y": 133,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    },
+                    {
+                      "x": 0,
+                      "y": 100,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    },
+                    {
+                      "x": 0,
+                      "y": 67,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    },
+                    {
+                      "x": 0,
+                      "y": 33,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    },
+                    {
+                      "x": 0,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#ddd",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    }
+                  ],
+                  "zindex": 0
+                }
+              ],
+              "x": 0.5,
+              "y": 0.5,
+              "orient": "left"
+            }
+          ],
+          "zindex": 0,
+          "aria": false
+        },
+        {
+          "marktype": "group",
+          "role": "axis",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "items": [
+                {
+                  "marktype": "rule",
+                  "role": "axis-tick",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 19,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 5
+                    },
+                    {
+                      "x": 1,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 5
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-label",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 10,
+                      "y": 7,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "",
+                      "angle": 270,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": null,
+                      "y": 7,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "angle": 270,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "rule",
+                  "role": "axis-domain",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": 20
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-title",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 10,
+                      "y": 11,
+                      "align": "center",
+                      "baseline": "top",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "column_name",
+                      "angle": 0,
+                      "font": "sans-serif",
+                      "fontSize": 11,
+                      "fontWeight": "bold"
+                    }
+                  ],
+                  "zindex": 0
+                }
+              ],
+              "x": 0.5,
+              "y": 200.5,
+              "orient": "bottom"
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "group",
+          "role": "axis",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "items": [
+                {
+                  "marktype": "rule",
+                  "role": "axis-tick",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 200,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 167,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 133,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 100,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 67,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 33,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-label",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": -7,
+                      "y": 200,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "0.0",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 166.66666666666666,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "0.2",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 133.33333333333331,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "0.4",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 100,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "0.6",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 66.66666666666666,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "0.8",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 33.33333333333333,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "1.0",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 0,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "1.2",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "rule",
+                  "role": "axis-domain",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 200,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 0
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-title",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": -24.9013671875,
+                      "y": 100,
+                      "align": "center",
+                      "baseline": "bottom",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "previous_sum",
+                      "angle": -90,
+                      "font": "sans-serif",
+                      "fontSize": 11,
+                      "fontWeight": "bold"
+                    }
+                  ],
+                  "zindex": 0
+                }
+              ],
+              "x": 0.5,
+              "y": 0.5,
+              "orient": "left"
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "rect",
+          "name": "layer_0_marks",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "x": -20,
+              "y": 0,
+              "width": 60,
+              "height": 200,
+              "fill": "#4c78a8",
+              "y2": 200,
+              "description": "column_name: Prior; previous_sum: 1.2",
+              "ariaRoleDescription": "bar"
+            }
+          ],
+          "zindex": 0
+        }
+      ],
+      "x": 0,
+      "y": 0,
+      "width": 20,
+      "height": 200,
+      "fill": "transparent",
+      "stroke": "#ddd"
+    }
+  ],
+  "zindex": 0
+}


### PR DESCRIPTION
Adds Rust and Python functions for converting Vega and Vega-Lite specs to the Vega scene graph JSON format.

I didn't add CLI entry points as this isn't a standard file format. The main motivation here is to support testing in the development of alternative Vega renderers. 

cc @lsh

----

Here are some interesting timing observations for a simple scatterplot based on https://altair-viz.github.io/gallery/scatter_tooltips.html

```python
import altair as alt
import pandas as pd
alt.data_transformers.disable_max_rows()
from vega_datasets import data

source = pd.concat([data.cars()]*500, axis=0).reset_index(drop=True)
print(len(source))

chart = alt.Chart(source).mark_circle(size=60).encode(
    x='Horsepower',
    y='Miles_per_Gallon',
    color='Origin',
).interactive()
chart_json = chart.to_dict()
# chart
```

The time to compute the scenegraph

```python
%%time
png = vlc.vegalite_to_scenegraph(chart_json)
```
```
CPU times: user 4.94 s, sys: 1.1 s, total: 6.04 s
Wall time: 4.24 s
```

The time to render to PNG

```python
%%time
png = vlc.vegalite_to_scenegraph(chart_json)
```
```
CPU times: user 7.48 s, sys: 1.12 s, total: 8.6 s
Wall time: 6.82 s
```

Ignoring any serialization overhead, this suggests that, for this example, Vega takes about 60% of the total render time to generate the scenegraph. The other 40% is taken by the Vega SVG renderer and resvg to render the SVG to PNG.  If we had a GPU accelerated renderer, we could potentially shrink this 40% significantly, but a large chunk of the runtime is the generation of the scene graph, which a renderer wouldn't improve.
