### PR TITLE
Support limiting the allowed base URLs for external data requests

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -225,7 +225,6 @@ import('{url}').then((sg) => {{
             // Create and initialize svg function string
             let function_str = r#"
 function vegaToView(vgSpec, allowedBaseUrls, errors) {
-    console.log('in vegaToView: ', allowedBaseUrls);
     let runtime = vega.parse(vgSpec);
     let baseURL = 'https://vega.github.io/vega-datasets/';
     const loader = vega.loader({ mode: 'http', baseURL });
@@ -234,7 +233,6 @@ function vegaToView(vgSpec, allowedBaseUrls, errors) {
     if (allowedBaseUrls != null) {
         loader.http = async (uri, options) => {
             const parsedUri = new URL(uri);
-            console.log(parsedUri);
             if (
                 allowedBaseUrls.every(
                     (allowedUrl) => !parsedUri.href.startsWith(allowedUrl),
@@ -519,7 +517,7 @@ vegaLiteToSvg_{ver_name:?}(
     errors,
 ).then((result) => {{
     if (errors != null && errors.length > 0) {{
-        throw new Error(`Conversion errors: ${{errors}}`);
+        throw new Error(`${{errors}}`);
     }}
     svg = result;
 }});
@@ -565,7 +563,7 @@ vegaLiteToScenegraph_{ver_name:?}(
     errors,
 ).then((result) => {{
     if (errors != null && errors.length > 0) {{
-        throw new Error(`Conversion errors: ${{errors}}`);
+        throw new Error(`${{errors}}`);
     }}
     sg = result;
 }})
@@ -603,7 +601,7 @@ vegaToSvg(
     errors,
 ).then((result) => {{
     if (errors != null && errors.length > 0) {{
-        throw new Error(`Conversion errors: ${{errors}}`);
+        throw new Error(`${{errors}}`);
     }}
     svg = result;
 }})

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -48,11 +48,17 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct VgOpts {
+    pub allowed_base_urls: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct VlOpts {
     pub config: Option<serde_json::Value>,
     pub theme: Option<String>,
     pub vl_version: VlVersion,
     pub show_warnings: bool,
+    pub allowed_base_urls: Option<Vec<String>>,
 }
 
 impl VlOpts {
@@ -218,24 +224,43 @@ import('{url}').then((sg) => {{
 
             // Create and initialize svg function string
             let function_str = r#"
-function vegaToView(vgSpec) {
+function vegaToView(vgSpec, allowedBaseUrls, errors) {
+    console.log('in vegaToView: ', allowedBaseUrls);
     let runtime = vega.parse(vgSpec);
-    const baseURL = 'https://vega.github.io/vega-datasets/';
+    let baseURL = 'https://vega.github.io/vega-datasets/';
     const loader = vega.loader({ mode: 'http', baseURL });
+    const originalHttp = loader.http.bind(loader);
+
+    if (allowedBaseUrls != null) {
+        loader.http = async (uri, options) => {
+            const parsedUri = new URL(uri);
+            console.log(parsedUri);
+            if (
+                allowedBaseUrls.every(
+                    (allowedUrl) => !parsedUri.href.startsWith(allowedUrl),
+                )
+            ) {
+                errors.push(`External data url not allowed: ${uri}`);
+                throw new Error(`External data url not allowed: ${uri}`);
+            }
+            return originalHttp(uri, options);
+        };
+    }
+
     return new vega.View(runtime, {renderer: 'none', loader});
 }
 
-function vegaToSvg(vgSpec) {
-    let view = vegaToView(vgSpec);
+function vegaToSvg(vgSpec, allowedBaseUrls, errors) {
+    let view = vegaToView(vgSpec, allowedBaseUrls, errors);
     let svgPromise = view.toSVG().finally(() => { view.finalize() });
     return svgPromise
 }
 
-function vegaToScenegraph(vgSpec) {
-    let view = vegaToView(vgSpec);
+function vegaToScenegraph(vgSpec, allowedBaseUrls, errors) {
+    let view = vegaToView(vgSpec, allowedBaseUrls, errors);
     let scenegraphPromise = view.runAsync().then(() => {
         return JSON.parse(JSON.parse(vega.sceneToJSON(view.scenegraph())));
-    });
+    }).finally(() => { view.finalize() });
     return scenegraphPromise
 }
 "#;
@@ -289,14 +314,14 @@ function compileVegaLite_{ver_name}(vlSpec, config, theme, warnings) {{
     return {ver_name}.compile(vlSpec, options).spec
 }}
 
-function vegaLiteToSvg_{ver_name}(vlSpec, config, theme, warnings) {{
+function vegaLiteToSvg_{ver_name}(vlSpec, config, theme, warnings, allowedBaseUrls, errors) {{
     let vgSpec = compileVegaLite_{ver_name}(vlSpec, config, theme, warnings);
-    return vegaToSvg(vgSpec)
+    return vegaToSvg(vgSpec, allowedBaseUrls, errors)
 }}
 
-function vegaLiteToScenegraph_{ver_name}(vlSpec, config, theme, warnings) {{
+function vegaLiteToScenegraph_{ver_name}(vlSpec, config, theme, warnings, allowedBaseUrls, errors) {{
     let vgSpec = compileVegaLite_{ver_name}(vlSpec, config, theme, warnings);
-    return vegaToScenegraph(vgSpec)
+    return vegaToScenegraph(vgSpec, allowedBaseUrls, errors)
 }}
 "#,
                 ver_name = format!("{:?}", vl_version),
@@ -438,6 +463,9 @@ function vegaLiteToScenegraph_{ver_name}(vlSpec, config, theme, warnings) {{
             Some(s) => format!("'{}'", s),
         };
 
+        let allowed_base_urls =
+            serde_json::to_string(&serde_json::Value::from(vl_opts.allowed_base_urls))?;
+
         let code = format!(
             r#"
 compileVegaLite_{ver_name:?}(
@@ -445,6 +473,7 @@ compileVegaLite_{ver_name:?}(
     JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({config_arg_id})),
     {theme_arg},
     {show_warnings},
+    {allowed_base_urls},
 )
 "#,
             ver_name = vl_opts.vl_version,
@@ -474,15 +503,24 @@ compileVegaLite_{ver_name:?}(
             Some(s) => format!("'{}'", s),
         };
 
+        let allowed_base_urls =
+            serde_json::to_string(&serde_json::Value::from(vl_opts.allowed_base_urls))?;
+
         let code = ModuleCode::from(format!(
             r#"
 var svg;
+var errors = [];
 vegaLiteToSvg_{ver_name:?}(
     JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({spec_arg_id})),
     JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({config_arg_id})),
     {theme_arg},
-    {show_warnings}
+    {show_warnings},
+    {allowed_base_urls},
+    errors,
 ).then((result) => {{
+    if (errors != null && errors.length > 0) {{
+        throw new Error(`Conversion errors: ${{errors}}`);
+    }}
     svg = result;
 }});
 "#,
@@ -518,12 +556,17 @@ vegaLiteToSvg_{ver_name:?}(
         let code = ModuleCode::from(format!(
             r#"
 var sg;
+var errors = [];
 vegaLiteToScenegraph_{ver_name:?}(
     JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({spec_arg_id})),
     JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({config_arg_id})),
     {theme_arg},
-    {show_warnings}
+    {show_warnings},
+    errors,
 ).then((result) => {{
+    if (errors != null && errors.length > 0) {{
+        throw new Error(`Conversion errors: ${{errors}}`);
+    }}
     sg = result;
 }})
 "#,
@@ -540,20 +583,31 @@ vegaLiteToScenegraph_{ver_name:?}(
         Ok(value)
     }
 
-    pub async fn vega_to_svg(&mut self, vg_spec: &serde_json::Value) -> Result<String, AnyError> {
+    pub async fn vega_to_svg(
+        &mut self,
+        vg_spec: &serde_json::Value,
+        vg_opts: VgOpts,
+    ) -> Result<String, AnyError> {
         self.init_vega().await?;
+        let allowed_base_urls =
+            serde_json::to_string(&serde_json::Value::from(vg_opts.allowed_base_urls))?;
 
         let arg_id = set_json_arg(vg_spec.clone())?;
         let code = ModuleCode::from(format!(
             r#"
 var svg;
+var errors = [];
 vegaToSvg(
-    JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({arg_id}))
+    JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({arg_id})),
+    {allowed_base_urls},
+    errors,
 ).then((result) => {{
+    if (errors != null && errors.length > 0) {{
+        throw new Error(`Conversion errors: ${{errors}}`);
+    }}
     svg = result;
 }})
-"#,
-            arg_id = arg_id
+"#
         ));
         self.worker.execute_script("<anon>", code)?;
         self.worker.run_event_loop(false).await?;
@@ -565,20 +619,23 @@ vegaToSvg(
     pub async fn vega_to_scenegraph(
         &mut self,
         vg_spec: &serde_json::Value,
+        vg_opts: VgOpts,
     ) -> Result<serde_json::Value, AnyError> {
         self.init_vega().await?;
+        let allowed_base_urls =
+            serde_json::to_string(&serde_json::Value::from(vg_opts.allowed_base_urls))?;
 
         let arg_id = set_json_arg(vg_spec.clone())?;
         let code = ModuleCode::from(format!(
             r#"
 var sg;
 vegaToScenegraph(
-    JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({arg_id}))
+    JSON.parse(Deno[Deno.internal].core.ops.op_get_json_arg({arg_id})),
+    {allowed_base_urls},
 ).then((result) => {{
     sg = result;
 }})
-"#,
-            arg_id = arg_id
+"#
         ));
         self.worker.execute_script("<anon>", code)?;
         self.worker.run_event_loop(false).await?;
@@ -630,10 +687,12 @@ pub enum VlConvertCommand {
     },
     VgToSvg {
         vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
         responder: oneshot::Sender<Result<String, AnyError>>,
     },
     VgToSg {
         vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
         responder: oneshot::Sender<Result<serde_json::Value, AnyError>>,
     },
     VlToSvg {
@@ -715,12 +774,20 @@ impl VlConverter {
                             let vega_spec = inner.vegalite_to_vega(&vl_spec, vl_opts).await;
                             responder.send(vega_spec).ok();
                         }
-                        VlConvertCommand::VgToSvg { vg_spec, responder } => {
-                            let svg_result = inner.vega_to_svg(&vg_spec).await;
+                        VlConvertCommand::VgToSvg {
+                            vg_spec,
+                            vg_opts,
+                            responder,
+                        } => {
+                            let svg_result = inner.vega_to_svg(&vg_spec, vg_opts).await;
                             responder.send(svg_result).ok();
                         }
-                        VlConvertCommand::VgToSg { vg_spec, responder } => {
-                            let sg_result = inner.vega_to_scenegraph(&vg_spec).await;
+                        VlConvertCommand::VgToSg {
+                            vg_spec,
+                            vg_opts,
+                            responder,
+                        } => {
+                            let sg_result = inner.vega_to_scenegraph(&vg_spec, vg_opts).await;
                             responder.send(sg_result).ok();
                         }
                         VlConvertCommand::VlToSvg {
@@ -791,10 +858,15 @@ impl VlConverter {
         }
     }
 
-    pub async fn vega_to_svg(&mut self, vg_spec: serde_json::Value) -> Result<String, AnyError> {
+    pub async fn vega_to_svg(
+        &mut self,
+        vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
+    ) -> Result<String, AnyError> {
         let (resp_tx, resp_rx) = oneshot::channel::<Result<String, AnyError>>();
         let cmd = VlConvertCommand::VgToSvg {
             vg_spec,
+            vg_opts,
             responder: resp_tx,
         };
 
@@ -818,10 +890,12 @@ impl VlConverter {
     pub async fn vega_to_scenegraph(
         &mut self,
         vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
     ) -> Result<serde_json::Value, AnyError> {
         let (resp_tx, resp_rx) = oneshot::channel::<Result<serde_json::Value, AnyError>>();
         let cmd = VlConvertCommand::VgToSg {
             vg_spec,
+            vg_opts,
             responder: resp_tx,
         };
 
@@ -909,11 +983,12 @@ impl VlConverter {
     pub async fn vega_to_png(
         &mut self,
         vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
         scale: Option<f32>,
         ppi: Option<f32>,
     ) -> Result<Vec<u8>, AnyError> {
         let scale = scale.unwrap_or(1.0);
-        let svg = self.vega_to_svg(vg_spec).await?;
+        let svg = self.vega_to_svg(vg_spec, vg_opts).await?;
         svg_to_png(&svg, scale, ppi)
     }
 
@@ -932,11 +1007,12 @@ impl VlConverter {
     pub async fn vega_to_jpeg(
         &mut self,
         vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
         scale: Option<f32>,
         quality: Option<u8>,
     ) -> Result<Vec<u8>, AnyError> {
         let scale = scale.unwrap_or(1.0);
-        let svg = self.vega_to_svg(vg_spec).await?;
+        let svg = self.vega_to_svg(vg_spec, vg_opts).await?;
         svg_to_jpeg(&svg, scale, quality)
     }
 
@@ -955,10 +1031,11 @@ impl VlConverter {
     pub async fn vega_to_pdf(
         &mut self,
         vg_spec: serde_json::Value,
+        vg_opts: VgOpts,
         scale: Option<f32>,
     ) -> Result<Vec<u8>, AnyError> {
         let scale = scale.unwrap_or(1.0);
-        let svg = self.vega_to_svg(vg_spec).await?;
+        let svg = self.vega_to_svg(vg_spec, vg_opts).await?;
         svg_to_pdf(&svg, scale)
     }
 

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -4,7 +4,7 @@ use clap::{arg, Parser, Subcommand};
 use itertools::Itertools;
 use std::path::Path;
 use std::str::FromStr;
-use vl_convert_rs::converter::{vega_to_url, vegalite_to_url, VlConverter, VlOpts};
+use vl_convert_rs::converter::{vega_to_url, vegalite_to_url, VgOpts, VlConverter, VlOpts};
 use vl_convert_rs::module_loader::import_map::VlVersion;
 use vl_convert_rs::text::register_font_directory;
 use vl_convert_rs::{anyhow, anyhow::bail};
@@ -84,6 +84,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega-Lite specification to an PNG image
@@ -124,6 +128,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega-Lite specification to an JPEG image
@@ -164,6 +172,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega-Lite specification to a PDF image
@@ -200,6 +212,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
@@ -257,6 +273,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega specification to an PNG image
@@ -281,6 +301,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega specification to an JPEG image
@@ -305,6 +329,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega specification to an PDF image
@@ -325,6 +353,10 @@ enum Commands {
         /// Additional directory to search for fonts
         #[arg(long)]
         font_dir: Option<String>,
+
+        /// Allowed base URL for external data requests. Default allows any base URL
+        #[arg(short, long)]
+        allowed_base_url: Option<Vec<String>>,
     },
 
     /// Convert a Vega specification to a URL that opens the chart in the Vega editor
@@ -468,9 +500,19 @@ async fn main() -> Result<(), anyhow::Error> {
             config,
             show_warnings,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
-            vl_2_svg(&input, &output, &vl_version, theme, config, show_warnings).await?
+            vl_2_svg(
+                &input,
+                &output,
+                &vl_version,
+                theme,
+                config,
+                show_warnings,
+                allowed_base_url,
+            )
+            .await?
         }
         Vl2png {
             input,
@@ -482,6 +524,7 @@ async fn main() -> Result<(), anyhow::Error> {
             ppi,
             show_warnings,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
             vl_2_png(
@@ -493,6 +536,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 scale,
                 ppi,
                 show_warnings,
+                allowed_base_url,
             )
             .await?
         }
@@ -506,6 +550,7 @@ async fn main() -> Result<(), anyhow::Error> {
             quality,
             show_warnings,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
             vl_2_jpeg(
@@ -517,6 +562,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 scale,
                 quality,
                 show_warnings,
+                allowed_base_url,
             )
             .await?
         }
@@ -529,6 +575,7 @@ async fn main() -> Result<(), anyhow::Error> {
             scale,
             show_warnings,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
             vl_2_pdf(
@@ -539,6 +586,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 config,
                 scale,
                 show_warnings,
+                allowed_base_url,
             )
             .await?
         }
@@ -570,6 +618,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         theme,
                         vl_version,
                         show_warnings: false,
+                        allowed_base_urls: None
                     },
                     bundle,
                 )
@@ -580,9 +629,10 @@ async fn main() -> Result<(), anyhow::Error> {
             input,
             output,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
-            vg_2_svg(&input, &output).await?
+            vg_2_svg(&input, &output, allowed_base_url).await?
         }
         Vg2png {
             input,
@@ -590,9 +640,10 @@ async fn main() -> Result<(), anyhow::Error> {
             scale,
             ppi,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
-            vg_2_png(&input, &output, scale, ppi).await?
+            vg_2_png(&input, &output, scale, ppi, allowed_base_url).await?
         }
         Vg2jpeg {
             input,
@@ -600,18 +651,20 @@ async fn main() -> Result<(), anyhow::Error> {
             scale,
             quality,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
-            vg_2_jpeg(&input, &output, scale, quality).await?
+            vg_2_jpeg(&input, &output, scale, quality, allowed_base_url).await?
         }
         Vg2pdf {
             input,
             output,
             scale,
             font_dir,
+            allowed_base_url,
         } => {
             register_font_dir(font_dir)?;
-            vg_2_pdf(&input, &output, scale).await?
+            vg_2_pdf(&input, &output, scale, allowed_base_url).await?
         }
         Vg2url { input, fullscreen } => {
             let vg_str = read_input_string(&input)?;
@@ -755,6 +808,7 @@ fn read_config_json(config: Option<String>) -> Result<Option<serde_json::Value>,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn vl_2_vg(
     input: &str,
     output: &str,
@@ -788,6 +842,7 @@ async fn vl_2_vg(
                 theme,
                 config,
                 show_warnings,
+                allowed_base_urls: None
             },
         )
         .await
@@ -818,7 +873,11 @@ async fn vl_2_vg(
     Ok(())
 }
 
-async fn vg_2_svg(input: &str, output: &str) -> Result<(), anyhow::Error> {
+async fn vg_2_svg(
+    input: &str,
+    output: &str,
+    allowed_base_urls: Option<Vec<String>>,
+) -> Result<(), anyhow::Error> {
     // Read input file
     let vega_str = read_input_string(input)?;
 
@@ -829,7 +888,10 @@ async fn vg_2_svg(input: &str, output: &str) -> Result<(), anyhow::Error> {
     let mut converter = VlConverter::new();
 
     // Perform conversion
-    let svg = match converter.vega_to_svg(vg_spec).await {
+    let svg = match converter
+        .vega_to_svg(vg_spec, VgOpts { allowed_base_urls })
+        .await
+    {
         Ok(svg) => svg,
         Err(err) => {
             bail!("Vega to SVG conversion failed: {}", err);
@@ -842,7 +904,13 @@ async fn vg_2_svg(input: &str, output: &str) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn vg_2_png(input: &str, output: &str, scale: f32, ppi: f32) -> Result<(), anyhow::Error> {
+async fn vg_2_png(
+    input: &str,
+    output: &str,
+    scale: f32,
+    ppi: f32,
+    allowed_base_urls: Option<Vec<String>>,
+) -> Result<(), anyhow::Error> {
     // Read input file
     let vega_str = read_input_string(input)?;
 
@@ -853,7 +921,15 @@ async fn vg_2_png(input: &str, output: &str, scale: f32, ppi: f32) -> Result<(),
     let mut converter = VlConverter::new();
 
     // Perform conversion
-    let png_data = match converter.vega_to_png(vg_spec, Some(scale), Some(ppi)).await {
+    let png_data = match converter
+        .vega_to_png(
+            vg_spec,
+            VgOpts { allowed_base_urls },
+            Some(scale),
+            Some(ppi),
+        )
+        .await
+    {
         Ok(png_data) => png_data,
         Err(err) => {
             bail!("Vega to PNG conversion failed: {}", err);
@@ -871,6 +947,7 @@ async fn vg_2_jpeg(
     output: &str,
     scale: f32,
     quality: u8,
+    allowed_base_urls: Option<Vec<String>>,
 ) -> Result<(), anyhow::Error> {
     // Read input file
     let vega_str = read_input_string(input)?;
@@ -883,7 +960,12 @@ async fn vg_2_jpeg(
 
     // Perform conversion
     let jpeg_data = match converter
-        .vega_to_jpeg(vg_spec, Some(scale), Some(quality))
+        .vega_to_jpeg(
+            vg_spec,
+            VgOpts { allowed_base_urls },
+            Some(scale),
+            Some(quality),
+        )
         .await
     {
         Ok(jpeg_data) => jpeg_data,
@@ -898,7 +980,12 @@ async fn vg_2_jpeg(
     Ok(())
 }
 
-async fn vg_2_pdf(input: &str, output: &str, scale: f32) -> Result<(), anyhow::Error> {
+async fn vg_2_pdf(
+    input: &str,
+    output: &str,
+    scale: f32,
+    allowed_base_urls: Option<Vec<String>>,
+) -> Result<(), anyhow::Error> {
     // Read input file
     let vega_str = read_input_string(input)?;
 
@@ -909,7 +996,10 @@ async fn vg_2_pdf(input: &str, output: &str, scale: f32) -> Result<(), anyhow::E
     let mut converter = VlConverter::new();
 
     // Perform conversion
-    let pdf_data = match converter.vega_to_pdf(vg_spec, Some(scale)).await {
+    let pdf_data = match converter
+        .vega_to_pdf(vg_spec, VgOpts { allowed_base_urls }, Some(scale))
+        .await
+    {
         Ok(pdf_data) => pdf_data,
         Err(err) => {
             bail!("Vega to PDF conversion failed: {}", err);
@@ -922,6 +1012,7 @@ async fn vg_2_pdf(input: &str, output: &str, scale: f32) -> Result<(), anyhow::E
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn vl_2_svg(
     input: &str,
     output: &str,
@@ -929,6 +1020,7 @@ async fn vl_2_svg(
     theme: Option<String>,
     config: Option<String>,
     show_warnings: bool,
+    allowed_base_urls: Option<Vec<String>>,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -954,6 +1046,7 @@ async fn vl_2_svg(
                 config,
                 theme,
                 show_warnings,
+                allowed_base_urls,
             },
         )
         .await
@@ -980,6 +1073,7 @@ async fn vl_2_png(
     scale: f32,
     ppi: f32,
     show_warnings: bool,
+    allowed_base_urls: Option<Vec<String>>,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -1005,6 +1099,7 @@ async fn vl_2_png(
                 config,
                 theme,
                 show_warnings,
+                allowed_base_urls,
             },
             Some(scale),
             Some(ppi),
@@ -1033,6 +1128,7 @@ async fn vl_2_jpeg(
     scale: f32,
     quality: u8,
     show_warnings: bool,
+    allowed_base_urls: Option<Vec<String>>,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -1058,6 +1154,7 @@ async fn vl_2_jpeg(
                 config,
                 theme,
                 show_warnings,
+                allowed_base_urls,
             },
             Some(scale),
             Some(quality),
@@ -1076,6 +1173,7 @@ async fn vl_2_jpeg(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn vl_2_pdf(
     input: &str,
     output: &str,
@@ -1084,6 +1182,7 @@ async fn vl_2_pdf(
     config: Option<String>,
     scale: f32,
     show_warnings: bool,
+    allowed_base_urls: Option<Vec<String>>,
 ) -> Result<(), anyhow::Error> {
     // Parse version
     let vl_version = parse_vl_version(vl_version)?;
@@ -1109,6 +1208,7 @@ async fn vl_2_pdf(
                 config,
                 theme,
                 show_warnings,
+                allowed_base_urls,
             },
             Some(scale),
         )

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -618,7 +618,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         theme,
                         vl_version,
                         show_warnings: false,
-                        allowed_base_urls: None
+                        allowed_base_urls: None,
                     },
                     bundle,
                 )
@@ -842,7 +842,7 @@ async fn vl_2_vg(
                 theme,
                 config,
                 show_warnings,
-                allowed_base_urls: None
+                allowed_base_urls: None,
             },
         )
         .await


### PR DESCRIPTION
Closes https://github.com/vega/vl-convert/issues/123

In preparation for using VlConvert to replace [vega-render-service](https://github.com/vega/vega-render-service), this PR adds the `allowed_base_urls` argument to all of the API's that construct a Vega View in Deno.

Example:

```python
import vl_convert as vlc

vl_spec = {
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "data": {"url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/movies.json"},
  "mark": "circle",
  "encoding": {
    "x": {
      "bin": {"maxbins": 10},
      "field": "IMDB Rating"
    },
    "y": {
      "bin": {"maxbins": 10},
      "field": "Rotten Tomatoes Rating"
    },
    "size": {"aggregate": "count"}
  }
}
```
```python
vlc.vegalite_to_png(vl_spec, allowed_base_urls=["https://raw.githubusercontent.com/vega/vega-datasets"])
```
```
b'\x89PNG\r\n\x1a\n\x00\x00\x00\...
```
```python
vlc.vegalite_to_png(vl_spec, allowed_base_urls=["https://bogus"])
```
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[8], line 1
----> 1 vlc.vegalite_to_png(vl_spec, allowed_base_urls=["https://bogus/"])

ValueError: Vega-Lite to PNG conversion failed:
Error: External data url not allowed: https://raw.githubusercontent.com/vega/vega-datasets/next/data/movies.json
    at <anon>:13:15
```