### PR TITLE
Support configurable renderer in html export

### DIFF
--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
@@ -190,7 +192,6 @@ fn vega_to_scenegraph(
 ///     time_format_locale (str | dict): d3-time-format locale name or dictionary
 /// Returns:
 ///     str: SVG image string
-#[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(
     text_signature = "(vl_spec, vl_version, config, theme, show_warnings, allowed_base_urls, format_locale, time_format_locale)"
@@ -259,7 +260,6 @@ fn vegalite_to_svg(
 ///     time_format_locale (str | dict): d3-time-format locale name or dictionary
 /// Returns:
 ///     str: SVG image string
-#[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(
     text_signature = "(vl_spec, vl_version, config, theme, show_warnings, allowed_base_urls, format_locale, time_format_locale)"
@@ -392,7 +392,6 @@ fn vega_to_png(
 #[pyo3(
     text_signature = "(vl_spec, vl_version, scale, ppi, config, theme, show_warnings, allowed_base_urls, format_locale, time_format_locale)"
 )]
-#[allow(clippy::too_many_arguments)]
 fn vegalite_to_png(
     vl_spec: PyObject,
     vl_version: Option<&str>,
@@ -525,7 +524,6 @@ fn vega_to_jpeg(
 #[pyo3(
     text_signature = "(vl_spec, vl_version, scale, quality, config, theme, show_warnings, allowed_base_urls, format_locale, time_format_locale)"
 )]
-#[allow(clippy::too_many_arguments)]
 fn vegalite_to_jpeg(
     vl_spec: PyObject,
     vl_version: Option<&str>,
@@ -646,7 +644,6 @@ fn vega_to_pdf(
 ///     time_format_locale (str | dict): d3-time-format locale name or dictionary
 /// Returns:
 ///     bytes: PDF image data
-#[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(
     text_signature = "(vl_spec, vl_version, scale, config, theme, allowed_base_urls, format_locale, time_format_locale)"
@@ -756,7 +753,7 @@ fn vega_to_url(vg_spec: PyObject, fullscreen: Option<bool>) -> PyResult<String> 
 ///     string: HTML document
 #[pyfunction]
 #[pyo3(
-    text_signature = "(vl_spec, vl_version, bundle, config, theme, format_locale, time_format_locale)"
+    text_signature = "(vl_spec, vl_version, bundle, config, theme, format_locale, time_format_locale, renderer)"
 )]
 fn vegalite_to_html(
     vl_spec: PyObject,
@@ -811,7 +808,7 @@ fn vegalite_to_html(
 /// Returns:
 ///     string: HTML document
 #[pyfunction]
-#[pyo3(text_signature = "(vg_spec, bundle, format_locale, time_format_locale)")]
+#[pyo3(text_signature = "(vg_spec, bundle, format_locale, time_format_locale, renderer)")]
 fn vega_to_html(
     vg_spec: PyObject,
     bundle: Option<bool>,

--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -128,13 +128,13 @@ def test_vegalite_to_html_no_bundle(name, vl_version):
     html = vlc.vegalite_to_html(
         vl_spec, vl_version=vl_version, bundle=False, theme="fivethirtyeight"
     )
-    assert '{"theme":"fivethirtyeight"}' in html
-    assert '{"theme":"dark"}' not in html
+    assert '"theme":"fivethirtyeight"' in html
+    assert '"theme":"dark"' not in html
 
     html = vlc.vegalite_to_html(
         vl_spec, vl_version=vl_version, bundle=False, theme="dark"
     )
-    assert '{"theme":"dark"}' in html
+    assert '"theme":"dark"' in html
 
 
 @pytest.mark.parametrize("name", ["circle_binned"])
@@ -163,13 +163,13 @@ def test_vegalite_to_html_bundle(name, vl_version):
     html = vlc.vegalite_to_html(
         vl_spec, vl_version=vl_version, bundle=True, theme="fivethirtyeight"
     )
-    assert '{"theme":"fivethirtyeight"}' in html
-    assert '{"theme":"dark"}' not in html
+    assert '"theme":"fivethirtyeight"' in html
+    assert '"theme":"dark"' not in html
 
     html = vlc.vegalite_to_html(
         vl_spec, vl_version=vl_version, bundle=True, theme="dark"
     )
-    assert '{"theme":"dark"}' in html
+    assert '"theme":"dark"' in html
 
 
 @pytest.mark.parametrize("name", ["circle_binned", "stacked_bar_h"])

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -356,7 +356,7 @@ mod test_vegalite_to_vega {
 mod test_vegalite_to_html_no_bundle {
     use crate::*;
     use futures::executor::block_on;
-    use vl_convert_rs::converter::VlOpts;
+    use vl_convert_rs::converter::{Renderer, VlOpts};
     use vl_convert_rs::VlConverter;
 
     #[rstest]
@@ -386,7 +386,7 @@ mod test_vegalite_to_html_no_bundle {
         let mut converter = VlConverter::new();
 
         let html_result = block_on(
-            converter.vegalite_to_html(vl_spec, VlOpts{vl_version, ..Default::default()}, false)
+            converter.vegalite_to_html(vl_spec, VlOpts{vl_version, ..Default::default()}, false, Renderer::Canvas)
         ).unwrap();
 
         // Check for expected patterns
@@ -404,7 +404,7 @@ mod test_vegalite_to_html_no_bundle {
 mod test_vegalite_to_html_bundle {
     use crate::*;
     use futures::executor::block_on;
-    use vl_convert_rs::converter::VlOpts;
+    use vl_convert_rs::converter::{Renderer, VlOpts};
     use vl_convert_rs::VlConverter;
 
     #[rstest]
@@ -434,7 +434,7 @@ mod test_vegalite_to_html_bundle {
         let mut converter = VlConverter::new();
 
         let html_result = block_on(
-            converter.vegalite_to_html(vl_spec, VlOpts{vl_version, ..Default::default()}, true)
+            converter.vegalite_to_html(vl_spec, VlOpts{vl_version, ..Default::default()}, true, Renderer::Svg)
         ).unwrap();
 
         // Check for expected patterns


### PR DESCRIPTION
Adds `renderer` argument to html export that may be set to svg, canvas, or hybrid to configure which renderer to configure Vega with in the exported html.