### PR TITLE
Replace log with tracing, instrument conversion functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.1",
  "serde",
 ]
 
@@ -3037,6 +3037,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +3476,12 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p224"
@@ -3970,7 +3995,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -4151,8 +4176,17 @@ checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.1",
+ "regex-syntax 0.8.1",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4163,8 +4197,14 @@ checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.1",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4768,6 +4808,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -5581,6 +5630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,6 +5852,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -6131,6 +6220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6156,6 +6251,7 @@ dependencies = [
  "shellexpand",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
  "vl-convert-rs",
 ]
 
@@ -6184,6 +6280,7 @@ dependencies = [
  "pyo3",
  "pythonize",
  "tokio",
+ "tracing-subscriber",
  "vl-convert-rs",
 ]
 
@@ -6215,6 +6312,8 @@ dependencies = [
  "tempfile",
  "tiny-skia",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "usvg",
  "vl-convert-pdf",
 ]

--- a/vl-convert-python/Cargo.toml
+++ b/vl-convert-python/Cargo.toml
@@ -23,4 +23,4 @@ lazy_static = "1.4.0"
 futures = "0.3.28"
 pythonize = "0.20.0"
 tokio = { version= "1.32" }
-
+tracing-subscriber = { version="0.3", features = ["env-filter"] }

--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -6,6 +6,7 @@ use pyo3::types::{PyBytes, PyDict};
 use pythonize::{depythonize, pythonize};
 use std::str::FromStr;
 use std::sync::Mutex;
+use tracing_subscriber::{fmt, fmt::format::FmtSpan, prelude::*, EnvFilter};
 use vl_convert_rs::converter::{FormatLocale, Renderer, TimeFormatLocale, VgOpts, VlOpts};
 use vl_convert_rs::html::bundle_vega_snippet;
 use vl_convert_rs::module_loader::import_map::VlVersion;
@@ -1139,6 +1140,12 @@ fn javascript_bundle(snippet: Option<String>, vl_version: Option<&str>) -> PyRes
 /// Convert Vega-Lite specifications to other formats
 #[pymodule]
 fn vl_convert(_py: Python, m: &PyModule) -> PyResult<()> {
+    // Initialize logging controlled by RUST_LOG environment variable
+    tracing_subscriber::registry()
+        .with(fmt::layer().with_span_events(FmtSpan::CLOSE))
+        .with(EnvFilter::from_default_env())
+        .init();
+
     m.add_function(wrap_pyfunction!(vegalite_to_vega, m)?)?;
     m.add_function(wrap_pyfunction!(vegalite_to_svg, m)?)?;
     m.add_function(wrap_pyfunction!(vegalite_to_scenegraph, m)?)?;

--- a/vl-convert-rs/Cargo.toml
+++ b/vl-convert-rs/Cargo.toml
@@ -36,8 +36,10 @@ http = "0.2.9"
 image = {version="0.24.7", default-features=false, features=["jpeg"]}
 lz-str = "0.2.1"
 regex = "1"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = {version="1.32", features=["macros", "rt"]}
 rstest = "0.18.2"
 dssim = "3.2.4"
+tracing-subscriber = { version="0.3", features = ["env-filter"] }

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -1047,9 +1047,6 @@ pub struct VlConverter {
 
 impl VlConverter {
     pub fn new() -> Self {
-        // Initialize environment logger
-        env_logger::try_init().ok();
-
         let (sender, mut receiver) = mpsc::channel::<VlConvertCommand>(32);
 
         let handle = Arc::new(thread::spawn(move || {
@@ -1120,6 +1117,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_vega(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1149,6 +1147,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vega_to_svg(
         &mut self,
         vg_spec: serde_json::Value,
@@ -1178,6 +1177,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vega_to_scenegraph(
         &mut self,
         vg_spec: serde_json::Value,
@@ -1210,6 +1210,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_svg(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1239,6 +1240,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_scenegraph(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1271,6 +1273,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vega_to_png(
         &mut self,
         vg_spec: serde_json::Value,
@@ -1283,6 +1286,7 @@ impl VlConverter {
         svg_to_png(&svg, scale, ppi)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_png(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1295,6 +1299,7 @@ impl VlConverter {
         svg_to_png(&svg, scale, ppi)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vega_to_jpeg(
         &mut self,
         vg_spec: serde_json::Value,
@@ -1307,6 +1312,7 @@ impl VlConverter {
         svg_to_jpeg(&svg, scale, quality)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_jpeg(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1319,6 +1325,7 @@ impl VlConverter {
         svg_to_jpeg(&svg, scale, quality)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vega_to_pdf(
         &mut self,
         vg_spec: serde_json::Value,
@@ -1330,6 +1337,7 @@ impl VlConverter {
         svg_to_pdf(&svg, scale)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_pdf(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1341,6 +1349,7 @@ impl VlConverter {
         svg_to_pdf(&svg, scale)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn get_vegaembed_bundle(
         &mut self,
         vl_version: VlVersion,
@@ -1414,6 +1423,7 @@ impl VlConverter {
         ))
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vegalite_to_html(
         &mut self,
         vl_spec: serde_json::Value,
@@ -1426,6 +1436,7 @@ impl VlConverter {
         self.build_html(&code, vl_version, bundle).await
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn vega_to_html(
         &mut self,
         vg_spec: serde_json::Value,
@@ -1437,6 +1448,7 @@ impl VlConverter {
         self.build_html(&code, Default::default(), bundle).await
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn get_local_tz(&mut self) -> Result<Option<String>, AnyError> {
         let (resp_tx, resp_rx) = oneshot::channel::<Result<Option<String>, AnyError>>();
         let cmd = VlConvertCommand::GetLocalTz { responder: resp_tx };
@@ -1461,6 +1473,7 @@ impl VlConverter {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn get_themes(&mut self) -> Result<serde_json::Value, AnyError> {
         let (resp_tx, resp_rx) = oneshot::channel::<Result<serde_json::Value, AnyError>>();
         let cmd = VlConvertCommand::GetThemes { responder: resp_tx };
@@ -1532,6 +1545,7 @@ pub fn encode_png(pixmap: Pixmap, ppi: f32) -> Result<Vec<u8>, AnyError> {
     Ok(data)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn svg_to_png(svg: &str, scale: f32, ppi: Option<f32>) -> Result<Vec<u8>, AnyError> {
     // default ppi to 72
     let ppi = ppi.unwrap_or(72.0);
@@ -1569,6 +1583,7 @@ pub fn svg_to_png(svg: &str, scale: f32, ppi: Option<f32>) -> Result<Vec<u8>, An
     }
 }
 
+#[tracing::instrument(skip_all)]
 pub fn svg_to_jpeg(svg: &str, scale: f32, quality: Option<u8>) -> Result<Vec<u8>, AnyError> {
     let png_bytes = svg_to_png(svg, scale, None)?;
     let img = ImageReader::new(Cursor::new(png_bytes))
@@ -1588,6 +1603,7 @@ pub fn svg_to_jpeg(svg: &str, scale: f32, quality: Option<u8>) -> Result<Vec<u8>
     Ok(jpeg_bytes)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn svg_to_pdf(svg: &str, scale: f32) -> Result<Vec<u8>, AnyError> {
     // Load system fonts
     let font_db = FONT_DB
@@ -1633,6 +1649,7 @@ fn parse_svg(svg: &str) -> Result<usvg::Tree, AnyError> {
     Ok(usvg::Tree::from_xmltree(&doc, &opts)?)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn vegalite_to_url(vl_spec: &serde_json::Value, fullscreen: bool) -> Result<String, AnyError> {
     let spec_str = serde_json::to_string(vl_spec)?;
     let compressed_data = lz_str::compress_to_encoded_uri_component(&spec_str);
@@ -1646,6 +1663,7 @@ pub fn vegalite_to_url(vl_spec: &serde_json::Value, fullscreen: bool) -> Result<
     ))
 }
 
+#[tracing::instrument(skip_all)]
 pub fn vega_to_url(vg_spec: &serde_json::Value, fullscreen: bool) -> Result<String, AnyError> {
     let spec_str = serde_json::to_string(vg_spec)?;
     let compressed_data = lz_str::compress_to_encoded_uri_component(&spec_str);

--- a/vl-convert-rs/src/image_loading.rs
+++ b/vl-convert-rs/src/image_loading.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
-use log::error;
 use reqwest::Client;
 use std::io::Write;
 use tokio::task;
+use tracing::error;
 use usvg::{ImageHrefResolver, ImageKind, Options};
 
 static VL_CONVERT_USER_AGENT: &str =

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -8,6 +8,7 @@ use vl_convert_rs::{VlConverter, VlVersion};
 
 use serde_json::Value;
 use std::sync::Once;
+use tracing_subscriber::{fmt, fmt::format::FmtSpan, prelude::*, EnvFilter};
 use vl_convert_rs::converter::{FormatLocale, TimeFormatLocale, VlOpts};
 
 static INIT: Once = Once::new();
@@ -19,6 +20,11 @@ pub fn initialize() {
         let fonts_dir = root_path.join("tests").join("fonts");
         register_font_directory(fonts_dir.to_str().unwrap())
             .expect("Failed to register test font directory");
+
+        tracing_subscriber::registry()
+            .with(fmt::layer().with_span_events(FmtSpan::CLOSE))
+            .with(EnvFilter::from_default_env())
+            .init();
     });
 }
 

--- a/vl-convert/Cargo.toml
+++ b/vl-convert/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.106"
 clap = {version="4.4.2", features=["derive"]}
 shellexpand = "3.1.0"
 itertools = "0.11.0"
+tracing-subscriber = { version="0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -4,6 +4,7 @@ use clap::{arg, Parser, Subcommand};
 use itertools::Itertools;
 use std::path::Path;
 use std::str::FromStr;
+use tracing_subscriber::{fmt, fmt::format::FmtSpan, prelude::*, EnvFilter};
 use vl_convert_rs::converter::{
     vega_to_url, vegalite_to_url, FormatLocale, Renderer, TimeFormatLocale, VgOpts, VlConverter,
     VlOpts,
@@ -562,6 +563,13 @@ enum Commands {
 async fn main() -> Result<(), anyhow::Error> {
     let args = Cli::parse();
     use crate::Commands::*;
+
+    // Initialize logging controlled by RUST_LOG environment variable
+    tracing_subscriber::registry()
+        .with(fmt::layer().with_span_events(FmtSpan::CLOSE))
+        .with(EnvFilter::from_default_env())
+        .init();
+
     match args.command {
         Vl2vg {
             input: input_vegalite_file,


### PR DESCRIPTION
Incorporates the tracing crate to instrument the conversion functions. For example, from Python:

```python
import os
os.environ["RUST_LOG"]="vl_convert"

...
png = vlc.vega_to_png(vg_spec)
```
```
2024-02-03T18:52:42.500059Z  INFO vega_to_png:vega_to_svg: vl_convert_rs::converter: close time.busy=18.2µs time.idle=237ms
2024-02-03T18:52:42.510416Z  INFO vega_to_png:svg_to_png: vl_convert_rs::converter: close time.busy=10.3ms time.idle=1.54µs
2024-02-03T18:52:42.510432Z  INFO vega_to_png: vl_convert_rs::converter: close time.busy=10.4ms time.idle=237ms
```