### PR TITLE
Fix build of macos intel wheels

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -263,7 +263,7 @@ jobs:
         path: dist
 
   build-wheels-osx-64:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
     - name: Install Protoc


### PR DESCRIPTION
need to pin to `macos-12` for intel wheel build.