### PR TITLE
feat: Adds `vl_convert.pyi` type stub

### DIFF
--- a/vl-convert-python/pyproject.toml
+++ b/vl-convert-python/pyproject.toml
@@ -19,6 +19,7 @@ target-version = "py310"
 line-length = 88
 indent-width = 4
 exclude = []
+include = ["vl_convert.pyi"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/vl-convert-python/pyproject.toml
+++ b/vl-convert-python/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 sdist-include = ["*_thirdparty.*"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py38"
 line-length = 88
 indent-width = 4
 exclude = []
@@ -78,3 +78,7 @@ ignore = [
 ]
 pydocstyle.convention = "numpy"
 isort.split-on-trailing-comma = false
+
+[tool.pyright]
+pythonPlatform="All"
+pythonVersion="3.8"

--- a/vl-convert-python/pyproject.toml
+++ b/vl-convert-python/pyproject.toml
@@ -13,3 +13,67 @@ classifiers = [
 
 [tool.maturin]
 sdist-include = ["*_thirdparty.*"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+indent-width = 4
+exclude = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = true
+line-ending = "lf"
+# https://docs.astral.sh/ruff/formatter/#docstring-formatting
+docstring-code-format = true
+docstring-code-line-length = 88
+
+[tool.ruff.lint]
+# https://docs.astral.sh/ruff/preview/
+preview = true
+
+# https://docs.astral.sh/ruff/settings/#lint_extend-safe-fixes
+extend-safe-fixes = [
+    # from __future__ import annotations #
+    # ---------------------------------- #
+    "UP006",
+    "UP007",
+    "UP008",
+    "TCH",
+    # unsorted-dunder-all
+    "RUF022",
+    # pydocstyle #
+    # ---------- #
+    # fits-on-one-line
+    "D200",
+    # escape-sequence-in-docstring
+    "D301",
+    # ends-in-period
+    "D400",
+]
+extend-select = [
+    "ANN",
+    "D",
+    "D213",
+    "D400",
+    "E",
+    "F",
+    "FA",
+    "I001",
+    "RUF",
+    "TCH",
+    "TID",
+    "UP",
+    "W", 
+]
+ignore = [
+    # indent-with-spaces
+    "D206",
+    # multi-line-summary-first-line ((D213) is the opposite of this)
+    "D212", 
+    # Line too long
+    "E501",
+]
+pydocstyle.convention = "numpy"
+isort.split-on-trailing-comma = false

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -204,7 +204,7 @@ def get_time_format_locale(name: TimeFormatLocaleName) -> dict[str, Any]:
     """
     ...
 
-def javascript_bundle(snippet: str, vl_version: str | None) -> str:
+def javascript_bundle(snippet: str, vl_version: str | None = None) -> str:
     """
     Create a JavaScript bundle containing the Vega Embed, Vega-Lite, and Vega libraries.
 
@@ -247,7 +247,9 @@ def register_font_directory(font_dir: str) -> bytes:
     """
     ...
 
-def svg_to_jpeg(svg: str, scale: float, quality: int | None) -> bytes:
+def svg_to_jpeg(
+    svg: str, scale: float | None = None, quality: int | None = None
+) -> bytes:
     """
     Convert an SVG image string to JPEG image data.
 
@@ -266,7 +268,7 @@ def svg_to_jpeg(svg: str, scale: float, quality: int | None) -> bytes:
     """
     ...
 
-def svg_to_pdf(svg: str, scale: float) -> bytes:
+def svg_to_pdf(svg: str, scale: float | None = None) -> bytes:
     """
     Convert an SVG image string to PDF document data.
 
@@ -283,7 +285,7 @@ def svg_to_pdf(svg: str, scale: float) -> bytes:
     """
     ...
 
-def svg_to_png(svg: str, scale: float, ppi: float | None) -> bytes:
+def svg_to_png(svg: str, scale: float | None = None, ppi: float | None = None) -> bytes:
     """
     Convert an SVG image string to PNG image data.
 
@@ -304,10 +306,10 @@ def svg_to_png(svg: str, scale: float, ppi: float | None) -> bytes:
 
 def vega_to_html(
     vg_spec: VlSpec,
-    bundle: bool | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
-    renderer: Renderer | None,
+    bundle: bool | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
+    renderer: Renderer | None = None,
 ) -> str:
     """
     Convert a Vega spec to a self-contained HTML document.
@@ -335,11 +337,11 @@ def vega_to_html(
 
 def vega_to_jpeg(
     vg_spec: VlSpec,
-    scale: float,
-    quality: int | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    scale: float | None = None,
+    quality: int | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega spec to JPEG image data.
@@ -368,10 +370,10 @@ def vega_to_jpeg(
 
 def vega_to_pdf(
     vg_spec: VlSpec,
-    scale: float,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    scale: float | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega spec to PDF format.
@@ -398,11 +400,11 @@ def vega_to_pdf(
 
 def vega_to_png(
     vg_spec: VlSpec,
-    scale: float,
-    ppi: float | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    scale: float | None = None,
+    ppi: float | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega spec to PNG image data.
@@ -431,9 +433,9 @@ def vega_to_png(
 
 def vega_to_scenegraph(
     vg_spec: VlSpec,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> dict[str, Any]:
     """
     Convert a Vega spec to a Vega Scenegraph.
@@ -458,9 +460,9 @@ def vega_to_scenegraph(
 
 def vega_to_svg(
     vg_spec: VlSpec,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> str:
     """
     Convert a Vega spec to an SVG image string.
@@ -483,7 +485,7 @@ def vega_to_svg(
     """
     ...
 
-def vega_to_url(vg_spec: VlSpec, fullscreen: bool | None) -> str:
+def vega_to_url(vg_spec: VlSpec, fullscreen: bool | None = None) -> str:
     """
     Convert a Vega spec to a URL that opens the chart in the Vega editor.
 
@@ -502,13 +504,13 @@ def vega_to_url(vg_spec: VlSpec, fullscreen: bool | None) -> str:
 
 def vegalite_to_html(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    bundle: bool | None,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
-    renderer: Renderer | None,
+    vl_version: str | None = None,
+    bundle: bool | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
+    renderer: Renderer | None = None,
 ) -> str:
     """
     Convert a Vega-Lite spec to self-contained HTML document using a particular version of the Vega-Lite JavaScript library.
@@ -543,15 +545,15 @@ def vegalite_to_html(
 
 def vegalite_to_jpeg(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    scale: float,
-    quality: int | None,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    show_warnings: bool | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    vl_version: str | None = None,
+    scale: float | None = None,
+    quality: int | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega-Lite spec to JPEG image data using a particular version of the Vega-Lite JavaScript library.
@@ -589,13 +591,13 @@ def vegalite_to_jpeg(
 
 def vegalite_to_pdf(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    scale: float,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    vl_version: str | None = None,
+    scale: float | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega-Lite spec to PDF image data using a particular version of the Vega-Lite JavaScript library.
@@ -629,15 +631,15 @@ def vegalite_to_pdf(
 
 def vegalite_to_png(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    scale: float,
-    ppi: float | None,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    show_warnings: bool | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    vl_version: str | None = None,
+    scale: float | None = None,
+    ppi: float | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega-Lite spec to PNG image data using a particular version of the Vega-Lite JavaScript library.
@@ -675,13 +677,13 @@ def vegalite_to_png(
 
 def vegalite_to_scenegraph(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    show_warnings: bool | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    vl_version: str | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> str:
     """
     Convert a Vega-Lite spec to a Vega Scenegraph using a particular version of the Vega-Lite JavaScript library.
@@ -715,13 +717,13 @@ def vegalite_to_scenegraph(
 
 def vegalite_to_svg(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    show_warnings: bool | None,
-    allowed_base_urls: list[str] | None,
-    format_locale: FormatLocale | None,
-    time_format_locale: TimeFormatLocale | None,
+    vl_version: str | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> str:
     """
     Convert a Vega-Lite spec to an SVG image string using a particular version of the Vega-Lite JavaScript library.
@@ -753,7 +755,7 @@ def vegalite_to_svg(
     """
     ...
 
-def vegalite_to_url(vl_spec: VlSpec, fullscreen: bool | None) -> str:
+def vegalite_to_url(vl_spec: VlSpec, fullscreen: bool | None = None) -> str:
     """
     Convert a Vega-Lite spec to a URL that opens the chart in the Vega editor.
 
@@ -772,10 +774,10 @@ def vegalite_to_url(vl_spec: VlSpec, fullscreen: bool | None) -> str:
 
 def vegalite_to_vega(
     vl_spec: VlSpec,
-    vl_version: str | None,
-    config: dict[str, Any] | None,
-    theme: VegaThemes | None,
-    show_warnings: bool | None,
+    vl_version: str | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
 ) -> dict[str, Any]:
     """
     Convert a Vega-Lite spec to a Vega spec using a particular version of the Vega-Lite JavaScript library.

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -124,9 +124,9 @@ if TYPE_CHECKING:
         "vox",
     ]
     Renderer: TypeAlias = Literal["canvas", "hybrid", "svg"]
-    FormatLocale: TypeAlias = Union[FormatLocaleName, Dict[str, Any]]
-    TimeFormatLocale: TypeAlias = Union[TimeFormatLocaleName, Dict[str, Any]]
-    VlSpec: TypeAlias = Union[str, Dict[str, Any]]
+    FormatLocale: TypeAlias = FormatLocaleName | dict[str, Any]
+    TimeFormatLocale: TypeAlias = TimeFormatLocaleName | dict[str, Any]
+    VlSpec: TypeAlias = str | dict[str, Any]
 
 __all__ = [
     "get_format_locale",
@@ -155,7 +155,7 @@ __all__ = [
     "vegalite_to_vega",
 ]
 
-def get_format_locale(name: FormatLocaleName) -> Dict[str, Any]:
+def get_format_locale(name: FormatLocaleName) -> dict[str, Any]:
     """
     Get the d3-format locale dict for a named locale.
 
@@ -172,7 +172,7 @@ def get_format_locale(name: FormatLocaleName) -> Dict[str, Any]:
     """
     ...
 
-def get_local_tz() -> Optional[str]:
+def get_local_tz() -> str | None:
     """
     Get the named local timezone that Vega uses to perform timezone calculations.
 
@@ -183,7 +183,7 @@ def get_local_tz() -> Optional[str]:
     """
     ...
 
-def get_themes() -> Dict[VegaThemes, Dict[str, Any]]:
+def get_themes() -> dict[VegaThemes, dict[str, Any]]:
     """
     Get the config dict for each built-in theme.
 
@@ -193,7 +193,7 @@ def get_themes() -> Dict[VegaThemes, Dict[str, Any]]:
     """
     ...
 
-def get_time_format_locale(name: TimeFormatLocaleName) -> Dict[str, Any]:
+def get_time_format_locale(name: TimeFormatLocaleName) -> dict[str, Any]:
     """
     Get the d3-time-format locale dict for a named locale.
 
@@ -210,9 +210,7 @@ def get_time_format_locale(name: TimeFormatLocaleName) -> Dict[str, Any]:
     """
     ...
 
-def javascript_bundle(
-    snippet: Optional[str] = None, vl_version: Optional[str] = None
-) -> str:
+def javascript_bundle(snippet: str, vl_version: str | None = None) -> str:
     """
     Create a JavaScript bundle containing the Vega Embed, Vega-Lite, and Vega libraries.
 
@@ -241,7 +239,6 @@ def javascript_bundle(
     ...
 
 def register_font_directory(font_dir: str) -> None:
-def register_font_directory(font_dir: str) -> None:
     """
     Register a directory of fonts for use in subsequent conversions.
 
@@ -253,12 +250,11 @@ def register_font_directory(font_dir: str) -> None:
     Returns
     -------
     None
-    None
     """
     ...
 
 def svg_to_jpeg(
-    svg: str, scale: Optional[float] = None, quality: Optional[int] = None
+    svg: str, scale: float | None = None, quality: int | None = None
 ) -> bytes:
     """
     Convert an SVG image string to JPEG image data.
@@ -278,7 +274,7 @@ def svg_to_jpeg(
     """
     ...
 
-def svg_to_pdf(svg: str, scale: Optional[float] = None) -> bytes:
+def svg_to_pdf(svg: str, scale: float | None = None) -> bytes:
     """
     Convert an SVG image string to PDF document data.
 
@@ -295,9 +291,7 @@ def svg_to_pdf(svg: str, scale: Optional[float] = None) -> bytes:
     """
     ...
 
-def svg_to_png(
-    svg: str, scale: Optional[float] = None, ppi: Optional[float] = None
-) -> bytes:
+def svg_to_png(svg: str, scale: float | None = None, ppi: float | None = None) -> bytes:
     """
     Convert an SVG image string to PNG image data.
 
@@ -318,13 +312,12 @@ def svg_to_png(
 
 def vega_to_html(
     vg_spec: VlSpec,
-    bundle: Optional[bool] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
-    renderer: Optional[Renderer] = None,
+    bundle: bool | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
+    renderer: Renderer | None = None,
 ) -> str:
     """
-    Convert a Vega spec to an HTML document, optionally bundling dependencies.
     Convert a Vega spec to an HTML document, optionally bundling dependencies.
 
     Parameters
@@ -350,11 +343,11 @@ def vega_to_html(
 
 def vega_to_jpeg(
     vg_spec: VlSpec,
-    scale: Optional[float] = None,
-    quality: Optional[int] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    scale: float | None = None,
+    quality: int | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega spec to JPEG image data.
@@ -383,10 +376,10 @@ def vega_to_jpeg(
 
 def vega_to_pdf(
     vg_spec: VlSpec,
-    scale: Optional[float] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    scale: float | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega spec to PDF format.
@@ -413,11 +406,11 @@ def vega_to_pdf(
 
 def vega_to_png(
     vg_spec: VlSpec,
-    scale: Optional[float] = None,
-    ppi: Optional[float] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    scale: float | None = None,
+    ppi: float | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega spec to PNG image data.
@@ -446,10 +439,10 @@ def vega_to_png(
 
 def vega_to_scenegraph(
     vg_spec: VlSpec,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
-) -> Dict[str, Any]:
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
+) -> dict[str, Any]:
     """
     Convert a Vega spec to a Vega Scenegraph.
 
@@ -468,15 +461,14 @@ def vega_to_scenegraph(
     Returns
     -------
     scenegraph dictionary
-    scenegraph dictionary
     """
     ...
 
 def vega_to_svg(
     vg_spec: VlSpec,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> str:
     """
     Convert a Vega spec to an SVG image string.
@@ -499,7 +491,7 @@ def vega_to_svg(
     """
     ...
 
-def vega_to_url(vg_spec: VlSpec, fullscreen: Optional[bool] = None) -> str:
+def vega_to_url(vg_spec: VlSpec, fullscreen: bool | None = None) -> str:
     """
     Convert a Vega spec to a URL that opens the chart in the Vega editor.
 
@@ -518,16 +510,15 @@ def vega_to_url(vg_spec: VlSpec, fullscreen: Optional[bool] = None) -> str:
 
 def vegalite_to_html(
     vl_spec: VlSpec,
-    vl_version: Optional[str] = None,
-    bundle: Optional[bool] = None,
-    config: Optional[Dict[str, Any]] = None,
-    theme: Optional[VegaThemes] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
-    renderer: Optional[Renderer] = None,
+    vl_version: str | None = None,
+    bundle: bool | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
+    renderer: Renderer | None = None,
 ) -> str:
     """
-    Convert a Vega-Lite spec to an HTML document, optionally bundling dependencies.
     Convert a Vega-Lite spec to an HTML document, optionally bundling dependencies.
 
     Parameters
@@ -560,15 +551,15 @@ def vegalite_to_html(
 
 def vegalite_to_jpeg(
     vl_spec: VlSpec,
-    vl_version: Optional[str] = None,
-    scale: Optional[float] = None,
-    quality: Optional[int] = None,
-    config: Optional[Dict[str, Any]] = None,
-    theme: Optional[VegaThemes] = None,
-    show_warnings: Optional[bool] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    vl_version: str | None = None,
+    scale: float | None = None,
+    quality: int | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega-Lite spec to JPEG image data using a particular version of the Vega-Lite JavaScript library.
@@ -606,13 +597,13 @@ def vegalite_to_jpeg(
 
 def vegalite_to_pdf(
     vl_spec: VlSpec,
-    vl_version: Optional[str] = None,
-    scale: Optional[float] = None,
-    config: Optional[Dict[str, Any]] = None,
-    theme: Optional[VegaThemes] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    vl_version: str | None = None,
+    scale: float | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega-Lite spec to PDF image data using a particular version of the Vega-Lite JavaScript library.
@@ -646,15 +637,15 @@ def vegalite_to_pdf(
 
 def vegalite_to_png(
     vl_spec: VlSpec,
-    vl_version: Optional[str] = None,
-    scale: Optional[float] = None,
-    ppi: Optional[float] = None,
-    config: Optional[Dict[str, Any]] = None,
-    theme: Optional[VegaThemes] = None,
-    show_warnings: Optional[bool] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    vl_version: str | None = None,
+    scale: float | None = None,
+    ppi: float | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> bytes:
     """
     Convert a Vega-Lite spec to PNG image data using a particular version of the Vega-Lite JavaScript library.
@@ -727,19 +718,18 @@ def vegalite_to_scenegraph(
     Returns
     -------
     scenegraph dictionary
-    scenegraph dictionary
     """
     ...
 
 def vegalite_to_svg(
     vl_spec: VlSpec,
-    vl_version: Optional[str] = None,
-    config: Optional[Dict[str, Any]] = None,
-    theme: Optional[VegaThemes] = None,
-    show_warnings: Optional[bool] = None,
-    allowed_base_urls: Optional[List[str]] = None,
-    format_locale: Optional[FormatLocale] = None,
-    time_format_locale: Optional[TimeFormatLocale] = None,
+    vl_version: str | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
+    allowed_base_urls: list[str] | None = None,
+    format_locale: FormatLocale | None = None,
+    time_format_locale: TimeFormatLocale | None = None,
 ) -> str:
     """
     Convert a Vega-Lite spec to an SVG image string using a particular version of the Vega-Lite JavaScript library.
@@ -771,7 +761,7 @@ def vegalite_to_svg(
     """
     ...
 
-def vegalite_to_url(vl_spec: VlSpec, fullscreen: Optional[bool] = None) -> str:
+def vegalite_to_url(vl_spec: VlSpec, fullscreen: bool | None = None) -> str:
     """
     Convert a Vega-Lite spec to a URL that opens the chart in the Vega editor.
 
@@ -790,10 +780,10 @@ def vegalite_to_url(vl_spec: VlSpec, fullscreen: Optional[bool] = None) -> str:
 
 def vegalite_to_vega(
     vl_spec: VlSpec,
-    vl_version: Optional[str] = None,
-    config: Optional[Dict[str, Any]] = None,
-    theme: Optional[VegaThemes] = None,
-    show_warnings: Optional[bool] = None,
+    vl_version: str | None = None,
+    config: dict[str, Any] | None = None,
+    theme: VegaThemes | None = None,
+    show_warnings: bool | None = None,
 ) -> dict[str, Any]:
     """
     Convert a Vega-Lite spec to a Vega spec using a particular version of the Vega-Lite JavaScript library.

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -1,7 +1,13 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, TypeAlias
+    import sys
+    from typing import Any, Literal
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
     FormatLocaleName: TypeAlias = Literal[
         "ar-001",
@@ -232,7 +238,7 @@ def javascript_bundle(snippet: str, vl_version: str | None = None) -> str:
     """
     ...
 
-def register_font_directory(font_dir: str) -> bytes:
+def register_font_directory(font_dir: str) -> None:
     """
     Register a directory of fonts for use in subsequent conversions.
 
@@ -243,7 +249,7 @@ def register_font_directory(font_dir: str) -> bytes:
 
     Returns
     -------
-    PNG image data.
+    None
     """
     ...
 
@@ -312,7 +318,7 @@ def vega_to_html(
     renderer: Renderer | None = None,
 ) -> str:
     """
-    Convert a Vega spec to a self-contained HTML document.
+    Convert a Vega spec to an HTML document, optionally bundling dependencies.
 
     Parameters
     ----------
@@ -454,7 +460,7 @@ def vega_to_scenegraph(
 
     Returns
     -------
-    scenegraph.
+    scenegraph dictionary
     """
     ...
 
@@ -513,7 +519,7 @@ def vegalite_to_html(
     renderer: Renderer | None = None,
 ) -> str:
     """
-    Convert a Vega-Lite spec to self-contained HTML document using a particular version of the Vega-Lite JavaScript library.
+    Convert a Vega-Lite spec to an HTML document, optionally bundling dependencies.
 
     Parameters
     ----------
@@ -684,7 +690,7 @@ def vegalite_to_scenegraph(
     allowed_base_urls: list[str] | None = None,
     format_locale: FormatLocale | None = None,
     time_format_locale: TimeFormatLocale | None = None,
-) -> str:
+) -> dict[str, Any]:
     """
     Convert a Vega-Lite spec to a Vega Scenegraph using a particular version of the Vega-Lite JavaScript library.
 
@@ -711,7 +717,7 @@ def vegalite_to_scenegraph(
 
     Returns
     -------
-    SVG image string.
+    scenegraph dictionary
     """
     ...
 

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -1,0 +1,801 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Literal, TypeAlias
+
+    FormatLocaleName: TypeAlias = Literal[
+        "ar-001",
+        "ar-AE",
+        "ar-BH",
+        "ar-DJ",
+        "ar-DZ",
+        "ar-EG",
+        "ar-EH",
+        "ar-ER",
+        "ar-IL",
+        "ar-IQ",
+        "ar-JO",
+        "ar-KM",
+        "ar-KW",
+        "ar-LB",
+        "ar-LY",
+        "ar-MA",
+        "ar-MR",
+        "ar-OM",
+        "ar-PS",
+        "ar-QA",
+        "ar-SA",
+        "ar-SD",
+        "ar-SO",
+        "ar-SS",
+        "ar-SY",
+        "ar-TD",
+        "ar-TN",
+        "ar-YE",
+        "ca-ES",
+        "cs-CZ",
+        "da-DK",
+        "de-CH",
+        "de-DE",
+        "en-CA",
+        "en-GB",
+        "en-IE",
+        "en-IN",
+        "en-US",
+        "es-BO",
+        "es-ES",
+        "es-MX",
+        "fi-FI",
+        "fr-CA",
+        "fr-FR",
+        "he-IL",
+        "hu-HU",
+        "it-IT",
+        "ja-JP",
+        "ko-KR",
+        "mk-MK",
+        "nl-NL",
+        "pl-PL",
+        "pt-BR",
+        "pt-PT",
+        "ru-RU",
+        "sl-SI",
+        "sv-SE",
+        "uk-UA",
+        "zh-CN",
+    ]
+    TimeFormatLocaleName: TypeAlias = Literal[
+        "ar-EG",
+        "ar-SY",
+        "ca-ES",
+        "cs-CZ",
+        "da-DK",
+        "de-CH",
+        "de-DE",
+        "en-CA",
+        "en-GB",
+        "en-US",
+        "es-ES",
+        "es-MX",
+        "fa-IR",
+        "fi-FI",
+        "fr-CA",
+        "fr-FR",
+        "he-IL",
+        "hr-HR",
+        "hu-HU",
+        "it-IT",
+        "ja-JP",
+        "ko-KR",
+        "mk-MK",
+        "nb-NO",
+        "nl-BE",
+        "nl-NL",
+        "pl-PL",
+        "pt-BR",
+        "ru-RU",
+        "sv-SE",
+        "tr-TR",
+        "uk-UA",
+        "vi-VN",
+        "zh-CN",
+        "zh-TW",
+    ]
+    VegaThemes: TypeAlias = Literal[
+        "carbong10",
+        "carbong100",
+        "carbong90",
+        "carbonwhite",
+        "dark",
+        "excel",
+        "fivethirtyeight",
+        "ggplot2",
+        "googlecharts",
+        "latimes",
+        "powerbi",
+        "quartz",
+        "urbaninstitute",
+        "vox",
+    ]
+    Renderer: TypeAlias = Literal["canvas", "hybrid", "svg"]
+    FormatLocale: TypeAlias = FormatLocaleName | dict[str, Any]
+    TimeFormatLocale: TypeAlias = TimeFormatLocaleName | dict[str, Any]
+    VlSpec: TypeAlias = str | dict[str, Any]
+
+__all__ = [
+    "get_format_locale",
+    "get_local_tz",
+    "get_themes",
+    "get_time_format_locale",
+    "javascript_bundle",
+    "register_font_directory",
+    "svg_to_jpeg",
+    "svg_to_pdf",
+    "svg_to_png",
+    "vega_to_html",
+    "vega_to_jpeg",
+    "vega_to_pdf",
+    "vega_to_png",
+    "vega_to_scenegraph",
+    "vega_to_svg",
+    "vega_to_url",
+    "vegalite_to_html",
+    "vegalite_to_jpeg",
+    "vegalite_to_pdf",
+    "vegalite_to_png",
+    "vegalite_to_scenegraph",
+    "vegalite_to_svg",
+    "vegalite_to_url",
+    "vegalite_to_vega",
+]
+
+def get_format_locale(name: FormatLocaleName) -> dict[str, Any]:
+    """
+    Get the d3-format locale dict for a named locale.
+
+    See https://github.com/d3/d3-format/tree/main/locale for available names
+
+    Parameters
+    ----------
+    name
+        d3-format locale name (e.g. 'it-IT')
+
+    Returns
+    -------
+    d3-format locale dict
+    """
+    ...
+
+def get_local_tz() -> str | None:
+    """
+    Get the named local timezone that Vega uses to perform timezone calculations.
+
+    Returns
+    -------
+    Named local timezone (e.g. "America/New_York"), or None if the local timezone
+    cannot be determined.
+    """
+    ...
+
+def get_themes() -> dict[VegaThemes, dict[str, Any]]:
+    """
+    Get the config dict for each built-in theme.
+
+    Returns
+    -------
+    dict from theme name to config object.
+    """
+    ...
+
+def get_time_format_locale(name: TimeFormatLocaleName) -> dict[str, Any]:
+    """
+    Get the d3-time-format locale dict for a named locale.
+
+    See https://github.com/d3/d3-time-format/tree/main/locale for available names
+
+    Parameters
+    ----------
+    name
+        d3-time-format locale name (e.g. 'it-IT')
+
+    Returns
+    -------
+    d3-time-format locale dict.
+    """
+    ...
+
+def javascript_bundle(snippet: str, vl_version: str | None) -> str:
+    """
+    Create a JavaScript bundle containing the Vega Embed, Vega-Lite, and Vega libraries.
+
+    Optionally, a JavaScript snippet may be provided that references Vega Embed
+    as `vegaEmbed`, Vega-Lite as `vegaLite`, Vega and `vega`, and the lodash.debounce
+    function as `lodashDebounce`.
+
+    The resulting string will include these JavaScript libraries and all of their
+    dependencies.
+    This bundle result is suitable for inclusion in an HTML <script> tag with
+    no external dependencies required.
+    The default snippet assigns `vegaEmbed`, `vegaLite`, and `vega` to the global
+    window object, making them available globally to other script tags.
+
+    Parameters
+    ----------
+    snippet
+        An ES6 JavaScript snippet which includes no imports
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15') (default to latest)
+
+    Returns
+    -------
+    Bundled snippet with all dependencies.
+    """
+    ...
+
+def register_font_directory(font_dir: str) -> bytes:
+    """
+    Register a directory of fonts for use in subsequent conversions.
+
+    Parameters
+    ----------
+    font_dir
+        Absolute path to a directory containing font files
+
+    Returns
+    -------
+    PNG image data.
+    """
+    ...
+
+def svg_to_jpeg(svg: str, scale: float, quality: int | None) -> bytes:
+    """
+    Convert an SVG image string to JPEG image data.
+
+    Parameters
+    ----------
+    svg
+        SVG image string
+    scale
+        Image scale factor (default 1.0)
+    quality
+        JPEG Quality between 0 (worst) and 100 (best). Default 90
+
+    Returns
+    -------
+    JPEG image data.
+    """
+    ...
+
+def svg_to_pdf(svg: str, scale: float) -> bytes:
+    """
+    Convert an SVG image string to PDF document data.
+
+    Parameters
+    ----------
+    svg
+        SVG image string
+    scale
+        Image scale factor (default 1.0)
+
+    Returns
+    -------
+    PDF document data.
+    """
+    ...
+
+def svg_to_png(svg: str, scale: float, ppi: float | None) -> bytes:
+    """
+    Convert an SVG image string to PNG image data.
+
+    Parameters
+    ----------
+    svg
+        SVG image string
+    scale
+        Image scale factor (default 1.0)
+    ppi
+        Pixels per inch (default 72)
+
+    Returns
+    -------
+    PNG image data.
+    """
+    ...
+
+def vega_to_html(
+    vg_spec: VlSpec,
+    bundle: bool | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+    renderer: Renderer | None,
+) -> str:
+    """
+    Convert a Vega spec to a self-contained HTML document.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    bundle
+        If True, bundle all dependencies in HTML file.
+        If False (default), HTML file will load dependencies from only CDN
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+    renderer
+        Vega renderer. One of 'svg' (default), 'canvas',
+        or 'hybrid' (where text is svg and other marks are canvas)
+
+    Returns
+    -------
+    HTML document.
+    """
+    ...
+
+def vega_to_jpeg(
+    vg_spec: VlSpec,
+    scale: float,
+    quality: int | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> bytes:
+    """
+    Convert a Vega spec to JPEG image data.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    scale
+        Image scale factor (default 1.0)
+    quality
+        JPEG Quality between 0 (worst) and 100 (best). Default 90
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    JPEG image data.
+    """
+    ...
+
+def vega_to_pdf(
+    vg_spec: VlSpec,
+    scale: float,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> bytes:
+    """
+    Convert a Vega spec to PDF format.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    scale
+        Image scale factor (default 1.0)
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    PDF file bytes.
+    """
+    ...
+
+def vega_to_png(
+    vg_spec: VlSpec,
+    scale: float,
+    ppi: float | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> bytes:
+    """
+    Convert a Vega spec to PNG image data.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    scale
+        Image scale factor (default 1.0)
+    ppi
+        Pixels per inch (default 72)
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    PNG image data.
+    """
+    ...
+
+def vega_to_scenegraph(
+    vg_spec: VlSpec,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> dict[str, Any]:
+    """
+    Convert a Vega spec to a Vega Scenegraph.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    scenegraph.
+    """
+    ...
+
+def vega_to_svg(
+    vg_spec: VlSpec,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> str:
+    """
+    Convert a Vega spec to an SVG image string.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    SVG image string.
+    """
+    ...
+
+def vega_to_url(vg_spec: VlSpec, fullscreen: bool | None) -> str:
+    """
+    Convert a Vega spec to a URL that opens the chart in the Vega editor.
+
+    Parameters
+    ----------
+    vg_spec
+        Vega JSON specification string or dict
+    fullscreen
+        Whether to open the chart in full screen in the editor
+
+    Returns
+    -------
+    URL string.
+    """
+    ...
+
+def vegalite_to_html(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    bundle: bool | None,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+    renderer: Renderer | None,
+) -> str:
+    """
+    Convert a Vega-Lite spec to self-contained HTML document using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    bundle
+        If True, bundle all dependencies in HTML file
+        If False (default), HTML file will load dependencies from only CDN
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+    renderer
+        Vega renderer. One of 'svg' (default), 'canvas',
+        or 'hybrid' (where text is svg and other marks are canvas)
+
+    Returns
+    -------
+    HTML document.
+    """
+    ...
+
+def vegalite_to_jpeg(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    scale: float,
+    quality: int | None,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    show_warnings: bool | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> bytes:
+    """
+    Convert a Vega-Lite spec to JPEG image data using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    scale
+        Image scale factor (default 1.0)
+    quality
+        JPEG Quality between 0 (worst) and 100 (best). Default 90
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    show_warnings
+        Whether to print Vega-Lite compilation warnings (default false)
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    JPEG image data.
+    """
+    ...
+
+def vegalite_to_pdf(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    scale: float,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> bytes:
+    """
+    Convert a Vega-Lite spec to PDF image data using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    scale
+        Image scale factor (default 1.0)
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    PDF image data.
+    """
+    ...
+
+def vegalite_to_png(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    scale: float,
+    ppi: float | None,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    show_warnings: bool | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> bytes:
+    """
+    Convert a Vega-Lite spec to PNG image data using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    scale
+        Image scale factor (default 1.0)
+    ppi
+        Pixels per inch (default 72)
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    show_warnings
+        Whether to print Vega-Lite compilation warnings (default false)
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    PNG image data.
+    """
+    ...
+
+def vegalite_to_scenegraph(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    show_warnings: bool | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> str:
+    """
+    Convert a Vega-Lite spec to a Vega Scenegraph using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    show_warnings
+        Whether to print Vega-Lite compilation warnings (default false)
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    SVG image string.
+    """
+    ...
+
+def vegalite_to_svg(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    show_warnings: bool | None,
+    allowed_base_urls: list[str] | None,
+    format_locale: FormatLocale | None,
+    time_format_locale: TimeFormatLocale | None,
+) -> str:
+    """
+    Convert a Vega-Lite spec to an SVG image string using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    show_warnings
+        Whether to print Vega-Lite compilation warnings (default false)
+    allowed_base_urls
+        List of allowed base URLs for external data requests.
+        Default allows any base URL
+    format_locale
+        d3-format locale name or dictionary
+    time_format_locale
+        d3-time-format locale name or dictionary
+
+    Returns
+    -------
+    SVG image string.
+    """
+    ...
+
+def vegalite_to_url(vl_spec: VlSpec, fullscreen: bool | None) -> str:
+    """
+    Convert a Vega-Lite spec to a URL that opens the chart in the Vega editor.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    fullscreen
+        Whether to open the chart in full screen in the editor
+
+    Returns
+    -------
+    URL string.
+    """
+    ...
+
+def vegalite_to_vega(
+    vl_spec: VlSpec,
+    vl_version: str | None,
+    config: dict[str, Any] | None,
+    theme: VegaThemes | None,
+    show_warnings: bool | None,
+) -> dict[str, Any]:
+    """
+    Convert a Vega-Lite spec to a Vega spec using a particular version of the Vega-Lite JavaScript library.
+
+    Parameters
+    ----------
+    vl_spec
+        Vega-Lite JSON specification string or dict
+    vl_version
+        Vega-Lite library version string (e.g. 'v5.15')
+        (default to latest)
+    config
+        Chart configuration object to apply during conversion
+    theme
+        Named theme (e.g. "dark") to apply during conversion
+    show_warnings
+        Whether to print Vega-Lite compilation warnings (default false)
+
+    Returns
+    -------
+    Vega JSON specification dict.
+    """
+    ...


### PR DESCRIPTION
Closes https://github.com/vega/vl-convert/issues/184

# Updated

Tried enabling `pyright` on the `tests/` directory and answered [my own question](https://github.com/vega/vl-convert/pull/185#discussion_r1734587493) on `Option`. 
With that fixed, this is an example in `VSCode`:

![image](https://github.com/user-attachments/assets/44a43786-bba0-4984-9319-d53900b67cbd)

# Suggestion
You could setup `mypy` to run on `tests/` to:
- Confirm whatever you've expected in a test will not raise a warning for users
- Notify if stubs become out of sync with the actual interface
