### PR TITLE
Update CLI help text for Vega-Lite 6.4, improve version update docs

### DIFF
--- a/vl-convert-vendor/CLAUDE.md
+++ b/vl-convert-vendor/CLAUDE.md
@@ -19,3 +19,5 @@ When adding/removing Vega-Lite versions, update:
 3. `vl-convert/tests/test_cli.rs` - version test values (multiple places)
 4. `vl-convert-python/tests/test_specs.py` - version test values (multiple places)
 5. `vl-convert-rs/tests/vl-specs/expected/` - add/remove version directories
+6. `vl-convert/src/main.rs` - `DEFAULT_VL_VERSION` constant and help text version lists (6 occurrences)
+7. `vl-convert/README.md` - help text examples showing version lists and defaults

--- a/vl-convert-vendor/README.md
+++ b/vl-convert-vendor/README.md
@@ -18,11 +18,14 @@ vl-convert inlines the source code of supported versions of Vega-Lite so that no
    - `vl-convert-rs/tests/test_specs.rs` (multiple test functions)
    - `vl-convert/tests/test_cli.rs` (multiple test functions)
    - `vl-convert-python/tests/test_specs.py` (multiple test functions)
-4. Run tests: `pixi run test-rs`. The new version tests will fail because expected output files don't exist yet.
-5. Create expected test outputs (see "Updating test snapshots" below).
-6. Optionally update `DEFAULT_VL_VERSION` in `vl-convert/src/main.rs` if this should become the new default.
-7. Run all tests to verify: `pixi run test-rs && pixi run test-cli`
-8. Commit updated files.
+4. Update CLI help text in:
+   - `vl-convert/src/main.rs` - Add the new version to help text version lists (6 occurrences of "One of 5.8, 5.14, ...")
+   - `vl-convert/README.md` - Update help text examples showing version lists
+5. Run tests: `pixi run test-rs`. The new version tests will fail because expected output files don't exist yet.
+6. Create expected test outputs (see "Updating test snapshots" below).
+7. Optionally update `DEFAULT_VL_VERSION` in `vl-convert/src/main.rs` if this should become the new default.
+8. Run all tests to verify: `pixi run test-rs && pixi run test-cli`
+9. Commit updated files.
 
 # Updating Vega version
 To update the Vega version:
@@ -40,8 +43,11 @@ When removing old versions (e.g., versions not used by any Altair release):
    - `vl-convert-rs/tests/test_specs.rs`
    - `vl-convert/tests/test_cli.rs`
    - `vl-convert-python/tests/test_specs.py`
-4. Remove the expected test output directory: `rm -rf vl-convert-rs/tests/vl-specs/expected/vX_Y`
-5. Run tests to verify: `pixi run test-rs && pixi run test-cli`
+4. Update CLI help text in:
+   - `vl-convert/src/main.rs` - Remove the version from help text version lists (6 occurrences)
+   - `vl-convert/README.md` - Update help text examples
+5. Remove the expected test output directory: `rm -rf vl-convert-rs/tests/vl-specs/expected/vX_Y`
+6. Run tests to verify: `pixi run test-rs && pixi run test-cli`
 
 # Updating test snapshots
 When tests fail due to missing or changed expected outputs:

--- a/vl-convert/README.md
+++ b/vl-convert/README.md
@@ -56,7 +56,7 @@ Usage: vl-convert vl2vg [OPTIONS] --input <INPUT> --output <OUTPUT>
 Options:
   -i, --input <INPUT>            Path to input Vega-Lite file
   -o, --output <OUTPUT>          Path to output Vega file to be created
-  -v, --vl-version <VL_VERSION>  Vega-Lite Version. One of 4.17, 5.8, 5.9, 5.13, 5.14, 5.15, 5.16, 5.17, 5.18, 5.19, 5.20 [default: 5.20]
+  -v, --vl-version <VL_VERSION>  Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4 [default: 6.4]
   -t, --theme <THEME>            Named theme provided by the vegaThemes package (e.g. "dark")
   -c, --config <CONFIG>          Path to Vega-Lite config file. Defaults to ~/.config/vl-convert/config.json
   -p, --pretty                   Pretty-print JSON in output file
@@ -86,7 +86,7 @@ Options:
   -o, --output <OUTPUT>
           Path to output SVG file to be created
   -v, --vl-version <VL_VERSION>
-          Vega-Lite Version. One of 4.17, 5.8, 5.13, 5.14, 5.15, 5.16, 5.17, 5.18, 5.19, 5.20 [default: 5.20]
+          Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4 [default: 6.4]
       --theme <THEME>
           Named theme provided by the vegaThemes package (e.g. "dark")
   -c, --config <CONFIG>
@@ -127,7 +127,7 @@ Options:
   -o, --output <OUTPUT>
           Path to output PNG file to be created
   -v, --vl-version <VL_VERSION>
-          Vega-Lite Version. One of 4.17, 5.8, 5.13, 5.14, 5.15, 5.16, 5.17, 5.18, 5.19, 5.20 [default: 5.20]
+          Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4 [default: 6.4]
       --theme <THEME>
           Named theme provided by the vegaThemes package (e.g. "dark")
   -c, --config <CONFIG>
@@ -171,7 +171,7 @@ Options:
   -o, --output <OUTPUT>
           Path to output PDF file to be created
   -v, --vl-version <VL_VERSION>
-          Vega-Lite Version. One of 4.17, 5.8, 5.13, 5.14, 5.15, 5.16, 5.17, 5.18, 5.19, 5.20 [default: 5.20]
+          Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4 [default: 6.4]
       --theme <THEME>
           Named theme provided by the vegaThemes package (e.g. "dark")
   -c, --config <CONFIG>
@@ -230,7 +230,7 @@ Options:
   -o, --output <OUTPUT>
           Path to output HTML file to be created
   -v, --vl-version <VL_VERSION>
-          Vega-Lite Version. One of 4.17, 5.8, 5.13, 5.14, 5.15, 5.16, 5.17, 5.18, 5.19, 5.20 [default: 5.20]
+          Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4 [default: 6.4]
       --theme <THEME>
           Named theme provided by the vegaThemes package (e.g. "dark")
   -c, --config <CONFIG>

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -12,7 +12,7 @@ use vl_convert_rs::module_loader::import_map::VlVersion;
 use vl_convert_rs::text::register_font_directory;
 use vl_convert_rs::{anyhow, anyhow::bail};
 
-const DEFAULT_VL_VERSION: &str = "5.21";
+const DEFAULT_VL_VERSION: &str = "6.4";
 const DEFAULT_CONFIG_PATH: &str = "~/.config/vl-convert/config.json";
 
 #[derive(Debug, Parser)] // requires `derive` feature
@@ -36,7 +36,7 @@ enum Commands {
         #[arg(short, long)]
         output: String,
 
-        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.19, 5.20, 5.21, 6.1
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
         #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
         vl_version: String,
 
@@ -68,7 +68,7 @@ enum Commands {
         #[arg(short, long)]
         output: String,
 
-        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.19, 5.20, 5.21, 6.1
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
         #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
         vl_version: String,
 
@@ -112,7 +112,7 @@ enum Commands {
         #[arg(short, long)]
         output: String,
 
-        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.19, 5.20, 5.21, 6.1
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
         #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
         vl_version: String,
 
@@ -164,7 +164,7 @@ enum Commands {
         #[arg(short, long)]
         output: String,
 
-        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.19, 5.20, 5.21, 6.1
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
         #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
         vl_version: String,
 
@@ -216,7 +216,7 @@ enum Commands {
         #[arg(short, long)]
         output: String,
 
-        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.19, 5.20, 5.21, 6.1
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
         #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
         vl_version: String,
 
@@ -272,7 +272,7 @@ enum Commands {
         #[arg(short, long)]
         output: String,
 
-        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.19, 5.20, 5.21, 6.1
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
         #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
         vl_version: String,
 


### PR DESCRIPTION
Follow on to https://github.com/vega/vl-convert/pull/224 with some minor updates, and doc update to clean things up going forward

---

## Summary
- Update `DEFAULT_VL_VERSION` from 5.21 to 6.4
- Update help text version lists: remove 5.19, add 6.4
- Update README help examples with current versions
- Add CLI help text files to version update documentation in vl-convert-vendor

This was missed during the Vega-Lite 6.4 update in #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)