### PR TITLE
DO NOT MERGE: Build 1.9.0.post1 packages

### DIFF
--- a/vl-convert-python/pyproject.toml
+++ b/vl-convert-python/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "vl-convert-python"
-dynamic = ["version", "readme", "license"]
+version = "1.9.0.post1"
+dynamic = ["readme", "license"]
 requires-python = ">=3.7"
 description = "Convert Vega-Lite chart specifications to SVG, PNG, or Vega"
 classifiers = [


### PR DESCRIPTION
## ⚠️ DO NOT MERGE THIS PR ⚠️

This PR is only for triggering the Release workflow to build `1.9.0.post1` Python packages with the corrected PyPI metadata (README and license).

### What this does
- Sets explicit `version = "1.9.0.post1"` in pyproject.toml (removed from `dynamic`)
- Keeps Cargo.toml at `1.9.0` (Cargo doesn't support PEP 440 .post syntax)

### After packages are published
Close this PR without merging. The version override should not be committed to main.

Related: #226