### PR TITLE
Add typed output structs, log capture, and request cancellation

### DIFF
--- a/vl-convert-python/src/lib.rs
+++ b/vl-convert-python/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, RwLock};
 use vl_convert_rs::configure_font_cache as configure_font_cache_rs;
 use vl_convert_rs::converter::{
     BaseUrlSetting, FormatLocale, GoogleFontRequest, HtmlOpts, JpegOpts, MissingFontsPolicy,
-    PdfOpts, PngOpts, Renderer, SvgOpts, TimeFormatLocale, ValueOrString, VgOpts, VlOpts,
+    PdfOpts, PngOpts, Renderer, SvgOpts, TimeFormatLocale, UrlOpts, ValueOrString, VgOpts, VlOpts,
     VlcConfig, ACCESS_DENIED_MARKER,
 };
 use vl_convert_rs::module_loader::import_map::{
@@ -621,11 +621,14 @@ fn vegalite_to_vega(
         format_locale: None,
         time_format_locale: None,
         google_fonts: effective_google_fonts(None),
-        vega_plugin: None,
+        ..Default::default()
     };
 
     let vega_spec = match run_converter_future(move |converter| async move {
-        converter.vegalite_to_vega(vl_spec, vl_opts).await
+        converter
+            .vegalite_to_vega(vl_spec, vl_opts)
+            .await
+            .map(|o| o.spec)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => {
@@ -670,6 +673,7 @@ fn vega_to_svg(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let svg_opts = SvgOpts {
@@ -677,7 +681,10 @@ fn vega_to_svg(
     };
 
     let svg = match run_converter_future(move |converter| async move {
-        converter.vega_to_svg(vg_spec, vg_opts, svg_opts).await
+        converter
+            .vega_to_svg(vg_spec, vg_opts, svg_opts)
+            .await
+            .map(|o| o.svg)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega to SVG conversion failed", err)),
@@ -712,13 +719,17 @@ fn vega_to_scenegraph(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     match format {
         "dict" => {
             let vg_spec = parse_json_spec(vg_spec)?;
             let sg = run_converter_future(move |converter| async move {
-                converter.vega_to_scenegraph(vg_spec, vg_opts).await
+                converter
+                    .vega_to_scenegraph(vg_spec, vg_opts)
+                    .await
+                    .map(|o| o.scenegraph)
             })
             .map_err(|err| prefixed_py_error("Vega to Scenegraph conversion failed", err))?;
             Python::with_gil(|py| -> PyResult<PyObject> {
@@ -730,7 +741,10 @@ fn vega_to_scenegraph(
         "msgpack" => {
             let vg_spec = parse_spec_to_value_or_string(vg_spec)?;
             let sg_bytes = run_converter_future(move |converter| async move {
-                converter.vega_to_scenegraph_msgpack(vg_spec, vg_opts).await
+                converter
+                    .vega_to_scenegraph_msgpack(vg_spec, vg_opts)
+                    .await
+                    .map(|o| o.data)
             })
             .map_err(|err| prefixed_py_error("Vega to Scenegraph conversion failed", err))?;
             Ok(Python::with_gil(|py| -> PyObject {
@@ -796,6 +810,7 @@ fn vegalite_to_svg(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let svg_opts = SvgOpts {
@@ -803,7 +818,10 @@ fn vegalite_to_svg(
     };
 
     let svg = match run_converter_future(move |converter| async move {
-        converter.vegalite_to_svg(vl_spec, vl_opts, svg_opts).await
+        converter
+            .vegalite_to_svg(vl_spec, vl_opts, svg_opts)
+            .await
+            .map(|o| o.svg)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega-Lite to SVG conversion failed", err)),
@@ -863,13 +881,17 @@ fn vegalite_to_scenegraph(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     match format {
         "dict" => {
             let vl_spec = parse_json_spec(vl_spec)?;
             let sg = run_converter_future(move |converter| async move {
-                converter.vegalite_to_scenegraph(vl_spec, vl_opts).await
+                converter
+                    .vegalite_to_scenegraph(vl_spec, vl_opts)
+                    .await
+                    .map(|o| o.scenegraph)
             })
             .map_err(|err| prefixed_py_error("Vega-Lite to Scenegraph conversion failed", err))?;
             Python::with_gil(|py| -> PyResult<PyObject> {
@@ -884,6 +906,7 @@ fn vegalite_to_scenegraph(
                 converter
                     .vegalite_to_scenegraph_msgpack(vl_spec, vl_opts)
                     .await
+                    .map(|o| o.data)
             })
             .map_err(|err| prefixed_py_error("Vega-Lite to Scenegraph conversion failed", err))?;
             Ok(Python::with_gil(|py| -> PyObject {
@@ -928,11 +951,15 @@ fn vega_to_png(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let png_opts = PngOpts { scale, ppi };
     let png_data = match run_converter_future(move |converter| async move {
-        converter.vega_to_png(vg_spec, vg_opts, png_opts).await
+        converter
+            .vega_to_png(vg_spec, vg_opts, png_opts)
+            .await
+            .map(|o| o.data)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega to PNG conversion failed", err)),
@@ -997,11 +1024,15 @@ fn vegalite_to_png(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let png_opts = PngOpts { scale, ppi };
     let png_data = match run_converter_future(move |converter| async move {
-        converter.vegalite_to_png(vl_spec, vl_opts, png_opts).await
+        converter
+            .vegalite_to_png(vl_spec, vl_opts, png_opts)
+            .await
+            .map(|o| o.data)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega-Lite to PNG conversion failed", err)),
@@ -1044,11 +1075,15 @@ fn vega_to_jpeg(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let jpeg_opts = JpegOpts { scale, quality };
     let jpeg_data = match run_converter_future(move |converter| async move {
-        converter.vega_to_jpeg(vg_spec, vg_opts, jpeg_opts).await
+        converter
+            .vega_to_jpeg(vg_spec, vg_opts, jpeg_opts)
+            .await
+            .map(|o| o.data)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega to JPEG conversion failed", err)),
@@ -1113,6 +1148,7 @@ fn vegalite_to_jpeg(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let jpeg_opts = JpegOpts { scale, quality };
@@ -1120,6 +1156,7 @@ fn vegalite_to_jpeg(
         converter
             .vegalite_to_jpeg(vl_spec, vl_opts, jpeg_opts)
             .await
+            .map(|o| o.data)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => {
@@ -1164,12 +1201,14 @@ fn vega_to_pdf(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let pdf_bytes = match run_converter_future(move |converter| async move {
         converter
             .vega_to_pdf(vg_spec, vg_opts, PdfOpts::default())
             .await
+            .map(|o| o.data)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega to PDF conversion failed", err)),
@@ -1227,12 +1266,14 @@ fn vegalite_to_pdf(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     let pdf_data = match run_converter_future(move |converter| async move {
         converter
             .vegalite_to_pdf(vl_spec, vl_opts, PdfOpts::default())
             .await
+            .map(|o| o.data)
     }) {
         Ok(vega_spec) => vega_spec,
         Err(err) => return Err(prefixed_py_error("Vega-Lite to PDF conversion failed", err)),
@@ -1256,7 +1297,9 @@ fn vegalite_to_url(vl_spec: PyObject, fullscreen: Option<bool>) -> PyResult<Stri
     let vl_spec = parse_json_spec(vl_spec)?;
     Ok(vl_convert_rs::converter::vegalite_to_url(
         &vl_spec,
-        fullscreen.unwrap_or(false),
+        UrlOpts {
+            fullscreen: fullscreen.unwrap_or(false),
+        },
     )?)
 }
 
@@ -1273,7 +1316,9 @@ fn vega_to_url(vg_spec: PyObject, fullscreen: Option<bool>) -> PyResult<String> 
     let vg_spec = parse_json_spec(vg_spec)?;
     Ok(vl_convert_rs::converter::vega_to_url(
         &vg_spec,
-        fullscreen.unwrap_or(false),
+        UrlOpts {
+            fullscreen: fullscreen.unwrap_or(false),
+        },
     )?)
 }
 
@@ -1334,6 +1379,7 @@ fn vegalite_to_html(
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
         vega_plugin,
+        ..Default::default()
     };
 
     let html_opts = HtmlOpts {
@@ -1344,6 +1390,7 @@ fn vegalite_to_html(
         converter
             .vegalite_to_html(vl_spec, vl_opts, html_opts)
             .await
+            .map(|o| o.html)
     })
     .map_err(|err| prefixed_py_error("Vega-Lite to HTML conversion failed", err))
 }
@@ -1385,13 +1432,17 @@ fn vega_to_html(
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
         vega_plugin,
+        ..Default::default()
     };
     let html_opts = HtmlOpts {
         bundle: bundle.unwrap_or(false),
         renderer,
     };
     run_converter_future(move |converter| async move {
-        converter.vega_to_html(vg_spec, vg_opts, html_opts).await
+        converter
+            .vega_to_html(vg_spec, vg_opts, html_opts)
+            .await
+            .map(|o| o.html)
     })
     .map_err(|err| prefixed_py_error("Vega to HTML conversion failed", err))
 }
@@ -1446,7 +1497,7 @@ fn vegalite_fonts(
         format_locale,
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
-        vega_plugin: None,
+        ..Default::default()
     };
 
     let result = run_converter_future(move |converter| async move {
@@ -1505,7 +1556,7 @@ fn vega_fonts(
         format_locale,
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
-        vega_plugin: None,
+        ..Default::default()
     };
 
     let result = run_converter_future(move |converter| async move {
@@ -1544,11 +1595,10 @@ fn vega_fonts(
 fn svg_to_png(svg: &str, scale: Option<f32>, ppi: Option<f32>) -> PyResult<PyObject> {
     let svg = svg.to_string();
     let png_opts = PngOpts { scale, ppi };
-    let png_data =
-        run_converter_future(
-            move |converter| async move { converter.svg_to_png(&svg, png_opts).await },
-        )
-        .map_err(|err| prefixed_py_error("SVG to PNG conversion failed", err))?;
+    let png_data = run_converter_future(move |converter| async move {
+        converter.svg_to_png(&svg, png_opts).await.map(|o| o.data)
+    })
+    .map_err(|err| prefixed_py_error("SVG to PNG conversion failed", err))?;
     Ok(Python::with_gil(|py| -> PyObject {
         PyBytes::new(py, png_data.as_slice()).into()
     }))
@@ -1568,7 +1618,7 @@ fn svg_to_jpeg(svg: &str, scale: Option<f32>, quality: Option<u8>) -> PyResult<P
     let svg = svg.to_string();
     let jpeg_opts = JpegOpts { scale, quality };
     let jpeg_data = run_converter_future(move |converter| async move {
-        converter.svg_to_jpeg(&svg, jpeg_opts).await
+        converter.svg_to_jpeg(&svg, jpeg_opts).await.map(|o| o.data)
     })
     .map_err(|err| prefixed_py_error("SVG to JPEG conversion failed", err))?;
     Ok(Python::with_gil(|py| -> PyObject {
@@ -1589,7 +1639,10 @@ fn svg_to_pdf(svg: &str, scale: Option<f32>) -> PyResult<PyObject> {
     warn_if_scale_not_one_for_pdf(scale)?;
     let svg = svg.to_string();
     let pdf_data = run_converter_future(move |converter| async move {
-        converter.svg_to_pdf(&svg, PdfOpts::default()).await
+        converter
+            .svg_to_pdf(&svg, PdfOpts::default())
+            .await
+            .map(|o| o.data)
     })
     .map_err(|err| prefixed_py_error("SVG to PDF conversion failed", err))?;
     Ok(Python::with_gil(|py| -> PyObject {
@@ -2138,12 +2191,17 @@ fn vegalite_to_vega_asyncio<'py>(
         format_locale: None,
         time_format_locale: None,
         google_fonts: effective_google_fonts(None),
-        vega_plugin: None,
+        ..Default::default()
     };
 
     run_converter_future_async(
         py,
-        move |converter| async move { converter.vegalite_to_vega(vl_spec, vl_opts).await },
+        move |converter| async move {
+            converter
+                .vegalite_to_vega(vl_spec, vl_opts)
+                .await
+                .map(|o| o.spec)
+        },
         "Vega-Lite to Vega conversion failed",
         |py, value| {
             pythonize(py, &value)
@@ -2172,6 +2230,7 @@ fn vega_to_svg_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
     let svg_opts = SvgOpts {
         bundle: bundle.unwrap_or(false),
@@ -2185,6 +2244,7 @@ fn vega_to_svg_asyncio<'py>(
         let value = converter
             .vega_to_svg(vg_spec, vg_opts, svg_opts)
             .await
+            .map(|o| o.svg)
             .map_err(|err| prefixed_py_error(error_prefix, err))?;
         Python::with_gil(|py| {
             pythonize(py, &value)
@@ -2212,6 +2272,7 @@ fn vega_to_scenegraph_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     match format {
@@ -2219,7 +2280,12 @@ fn vega_to_scenegraph_asyncio<'py>(
             let vg_spec = parse_json_spec(vg_spec)?;
             run_converter_future_async(
                 py,
-                move |converter| async move { converter.vega_to_scenegraph(vg_spec, vg_opts).await },
+                move |converter| async move {
+                    converter
+                        .vega_to_scenegraph(vg_spec, vg_opts)
+                        .await
+                        .map(|o| o.scenegraph)
+                },
                 "Vega to Scenegraph conversion failed",
                 |py, value| {
                     pythonize(py, &value)
@@ -2233,7 +2299,10 @@ fn vega_to_scenegraph_asyncio<'py>(
             run_converter_future_async(
                 py,
                 move |converter| async move {
-                    converter.vega_to_scenegraph_msgpack(vg_spec, vg_opts).await
+                    converter
+                        .vega_to_scenegraph_msgpack(vg_spec, vg_opts)
+                        .await
+                        .map(|o| o.data)
                 },
                 "Vega to Scenegraph conversion failed",
                 |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2280,6 +2349,7 @@ fn vegalite_to_svg_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
     let svg_opts = SvgOpts {
         bundle: bundle.unwrap_or(false),
@@ -2293,6 +2363,7 @@ fn vegalite_to_svg_asyncio<'py>(
         let value = converter
             .vegalite_to_svg(vl_spec, vl_opts, svg_opts)
             .await
+            .map(|o| o.svg)
             .map_err(|err| prefixed_py_error(error_prefix, err))?;
         Python::with_gil(|py| {
             pythonize(py, &value)
@@ -2336,6 +2407,7 @@ fn vegalite_to_scenegraph_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     match format {
@@ -2343,7 +2415,12 @@ fn vegalite_to_scenegraph_asyncio<'py>(
             let vl_spec = parse_json_spec(vl_spec)?;
             run_converter_future_async(
                 py,
-                move |converter| async move { converter.vegalite_to_scenegraph(vl_spec, vl_opts).await },
+                move |converter| async move {
+                    converter
+                        .vegalite_to_scenegraph(vl_spec, vl_opts)
+                        .await
+                        .map(|o| o.scenegraph)
+                },
                 "Vega-Lite to Scenegraph conversion failed",
                 |py, value| {
                     pythonize(py, &value)
@@ -2360,6 +2437,7 @@ fn vegalite_to_scenegraph_asyncio<'py>(
                     converter
                         .vegalite_to_scenegraph_msgpack(vl_spec, vl_opts)
                         .await
+                        .map(|o| o.data)
                 },
                 "Vega-Lite to Scenegraph conversion failed",
                 |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2393,6 +2471,7 @@ fn vega_to_png_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2401,6 +2480,7 @@ fn vega_to_png_asyncio<'py>(
             converter
                 .vega_to_png(vg_spec, vg_opts, PngOpts { scale, ppi })
                 .await
+                .map(|o| o.data)
         },
         "Vega to PNG conversion failed",
         |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2443,6 +2523,7 @@ fn vegalite_to_png_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2451,6 +2532,7 @@ fn vegalite_to_png_asyncio<'py>(
             converter
                 .vegalite_to_png(vl_spec, vl_opts, PngOpts { scale, ppi })
                 .await
+                .map(|o| o.data)
         },
         "Vega-Lite to PNG conversion failed",
         |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2479,6 +2561,7 @@ fn vega_to_jpeg_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2487,6 +2570,7 @@ fn vega_to_jpeg_asyncio<'py>(
             converter
                 .vega_to_jpeg(vg_spec, vg_opts, JpegOpts { scale, quality })
                 .await
+                .map(|o| o.data)
         },
         "Vega to JPEG conversion failed",
         |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2529,6 +2613,7 @@ fn vegalite_to_jpeg_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2537,6 +2622,7 @@ fn vegalite_to_jpeg_asyncio<'py>(
             converter
                 .vegalite_to_jpeg(vl_spec, vl_opts, JpegOpts { scale, quality })
                 .await
+                .map(|o| o.data)
         },
         "Vega-Lite to JPEG conversion failed",
         |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2563,6 +2649,7 @@ fn vega_to_pdf_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2571,6 +2658,7 @@ fn vega_to_pdf_asyncio<'py>(
             converter
                 .vega_to_pdf(vg_spec, vg_opts, PdfOpts::default())
                 .await
+                .map(|o| o.data)
         },
         "Vega to PDF conversion failed",
         |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2611,6 +2699,7 @@ fn vegalite_to_pdf_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(None),
         vega_plugin,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2619,6 +2708,7 @@ fn vegalite_to_pdf_asyncio<'py>(
             converter
                 .vegalite_to_pdf(vl_spec, vl_opts, PdfOpts::default())
                 .await
+                .map(|o| o.data)
         },
         "Vega-Lite to PDF conversion failed",
         |py, value| Ok(PyBytes::new(py, value.as_slice()).into()),
@@ -2634,7 +2724,12 @@ fn vegalite_to_url_asyncio<'py>(
     fullscreen: Option<bool>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let vl_spec = parse_json_spec(vl_spec)?;
-    let url = vl_convert_rs::converter::vegalite_to_url(&vl_spec, fullscreen.unwrap_or(false))?;
+    let url = vl_convert_rs::converter::vegalite_to_url(
+        &vl_spec,
+        UrlOpts {
+            fullscreen: fullscreen.unwrap_or(false),
+        },
+    )?;
     future_into_py_object(py, async move {
         Python::with_gil(|py| {
             pythonize(py, &url)
@@ -2653,7 +2748,12 @@ fn vega_to_url_asyncio<'py>(
     fullscreen: Option<bool>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let vg_spec = parse_json_spec(vg_spec)?;
-    let url = vl_convert_rs::converter::vega_to_url(&vg_spec, fullscreen.unwrap_or(false))?;
+    let url = vl_convert_rs::converter::vega_to_url(
+        &vg_spec,
+        UrlOpts {
+            fullscreen: fullscreen.unwrap_or(false),
+        },
+    )?;
     future_into_py_object(py, async move {
         Python::with_gil(|py| {
             pythonize(py, &url)
@@ -2703,6 +2803,7 @@ fn vegalite_to_html_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
         vega_plugin,
+        ..Default::default()
     };
 
     let converter = converter_read_handle()
@@ -2720,6 +2821,7 @@ fn vegalite_to_html_asyncio<'py>(
                 },
             )
             .await
+            .map(|o| o.html)
             .map_err(|err| prefixed_py_error(error_prefix, err))?;
         Python::with_gil(|py| {
             pythonize(py, &value)
@@ -2754,6 +2856,7 @@ fn vega_to_html_asyncio<'py>(
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
         vega_plugin,
+        ..Default::default()
     };
 
     let converter = converter_read_handle()
@@ -2771,6 +2874,7 @@ fn vega_to_html_asyncio<'py>(
                 },
             )
             .await
+            .map(|o| o.html)
             .map_err(|err| prefixed_py_error(error_prefix, err))?;
         Python::with_gil(|py| {
             pythonize(py, &value)
@@ -2814,7 +2918,7 @@ fn vegalite_fonts_asyncio<'py>(
         format_locale,
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
-        vega_plugin: None,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2865,7 +2969,7 @@ fn vega_fonts_asyncio<'py>(
         format_locale,
         time_format_locale,
         google_fonts: effective_google_fonts(google_fonts),
-        vega_plugin: None,
+        ..Default::default()
     };
 
     run_converter_future_async(
@@ -2907,7 +3011,12 @@ fn svg_to_png_asyncio<'py>(
     let svg = svg.to_string();
     run_converter_future_async(
         py,
-        move |converter| async move { converter.svg_to_png(&svg, PngOpts { scale, ppi }).await },
+        move |converter| async move {
+            converter
+                .svg_to_png(&svg, PngOpts { scale, ppi })
+                .await
+                .map(|o| o.data)
+        },
         "SVG to PNG conversion failed",
         |py, data| Ok(PyBytes::new(py, data.as_slice()).into()),
     )
@@ -2929,6 +3038,7 @@ fn svg_to_jpeg_asyncio<'py>(
             converter
                 .svg_to_jpeg(&svg, JpegOpts { scale, quality })
                 .await
+                .map(|o| o.data)
         },
         "SVG to JPEG conversion failed",
         |py, data| Ok(PyBytes::new(py, data.as_slice()).into()),
@@ -2947,7 +3057,12 @@ fn svg_to_pdf_asyncio<'py>(
     let svg = svg.to_string();
     run_converter_future_async(
         py,
-        move |converter| async move { converter.svg_to_pdf(&svg, PdfOpts::default()).await },
+        move |converter| async move {
+            converter
+                .svg_to_pdf(&svg, PdfOpts::default())
+                .await
+                .map(|o| o.data)
+        },
         "SVG to PDF conversion failed",
         |py, data| Ok(PyBytes::new(py, data.as_slice()).into()),
     )

--- a/vl-convert-rs/examples/conversion1.rs
+++ b/vl-convert-rs/examples/conversion1.rs
@@ -3,7 +3,7 @@ use vl_convert_rs::{VlConverter, VlVersion};
 
 #[tokio::main]
 async fn main() {
-    let mut converter = VlConverter::new();
+    let converter = VlConverter::new();
 
     let vl_spec: serde_json::Value = serde_json::from_str(
         r#"
@@ -26,7 +26,7 @@ async fn main() {
     )
     .unwrap();
 
-    let vega_spec = converter
+    let vega_output = converter
         .vegalite_to_vega(
             vl_spec,
             VlOpts {
@@ -37,5 +37,5 @@ async fn main() {
         .await
         .expect("Failed to perform Vega-Lite to Vega conversion");
 
-    println!("{}", vega_spec)
+    println!("{}", vega_output.spec)
 }

--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -162,15 +162,55 @@ type WorkFn = Box<
 struct QueuedWork {
     work: WorkFn,
     ticket: OutstandingTicket,
+    caller_gone: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl QueuedWork {
-    fn new(work: WorkFn, ticket: OutstandingTicket) -> Self {
-        Self { work, ticket }
+    fn new(
+        work: WorkFn,
+        ticket: OutstandingTicket,
+        caller_gone: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        Self {
+            work,
+            ticket,
+            caller_gone,
+        }
     }
 
-    fn into_parts(self) -> (WorkFn, OutstandingTicket) {
-        (self.work, self.ticket)
+    fn into_parts(
+        self,
+    ) -> (
+        WorkFn,
+        OutstandingTicket,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        (self.work, self.ticket, self.caller_gone)
+    }
+}
+
+/// Drop guard that signals `caller_gone` when the caller's future is dropped
+/// (e.g. by HTTP timeout). Call `disarm()` on normal completion to prevent
+/// spurious signaling.
+struct CallerGoneGuard {
+    flag: Arc<std::sync::atomic::AtomicBool>,
+    armed: bool,
+}
+
+impl CallerGoneGuard {
+    fn new(flag: Arc<std::sync::atomic::AtomicBool>) -> Self {
+        Self { flag, armed: true }
+    }
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CallerGoneGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.flag.store(true, std::sync::atomic::Ordering::Release);
+        }
     }
 }
 
@@ -374,9 +414,14 @@ fn spawn_worker_pool(
                 while let Some(queued_work) = rx.recv().await {
                     // Keep the ticket alive for the full loop iteration so outstanding
                     // covers the work execution (drop happens at iteration end).
-                    let (work, _ticket) = queued_work.into_parts();
+                    let (work, _ticket, caller_gone) = queued_work.into_parts();
 
-                    let timer = inner.start_conversion_timer();
+                    // Skip work if the caller already timed out or disconnected
+                    if caller_gone.load(std::sync::atomic::Ordering::Acquire) {
+                        continue;
+                    }
+
+                    let timer = inner.start_conversion_timer(caller_gone);
                     (work)(&mut inner).await;
                     inner.cancel_conversion_timer(timer);
 
@@ -585,6 +630,45 @@ impl ValueOrString {
     }
 }
 
+/// Apply background, width, and height overrides to a spec.
+/// Works for both Vega and Vega-Lite specs.
+pub(crate) fn apply_spec_overrides(
+    spec: ValueOrString,
+    background: &Option<String>,
+    width: Option<f32>,
+    height: Option<f32>,
+) -> Result<ValueOrString, AnyError> {
+    if background.is_none() && width.is_none() && height.is_none() {
+        return Ok(spec);
+    }
+    let mut val = spec.to_value()?;
+    if let Some(obj) = val.as_object_mut() {
+        if let Some(bg) = background {
+            obj.insert(
+                "background".to_string(),
+                serde_json::Value::String(bg.clone()),
+            );
+        }
+        if let Some(w) = width {
+            obj.insert(
+                "width".to_string(),
+                serde_json::Value::Number(
+                    serde_json::Number::from_f64(w as f64).unwrap_or(serde_json::Number::from(0)),
+                ),
+            );
+        }
+        if let Some(h) = height {
+            obj.insert(
+                "height".to_string(),
+                serde_json::Value::Number(
+                    serde_json::Number::from_f64(h as f64).unwrap_or(serde_json::Number::from(0)),
+                ),
+            );
+        }
+    }
+    Ok(ValueOrString::Value(val))
+}
+
 /// How to handle fonts referenced in a spec but not available on the system.
 ///
 /// Only the **first** non-generic font in each CSS `font-family` string is
@@ -755,6 +839,9 @@ pub struct VlcConfig {
     /// Defaults to false. When enabled, requests can include a `vega_plugin`
     /// field that runs on an ephemeral V8 isolate (50-100ms overhead).
     pub allow_per_request_plugins: bool,
+    /// Whether to allow per-request `google_fonts` / `auto_google_fonts` overrides.
+    /// Defaults to false. When false, requests containing these fields are rejected.
+    pub allow_google_fonts: bool,
     /// Domain allowlist for HTTP imports inside per-request plugins.
     /// Separate from `plugin_import_domains` (which controls config-level
     /// plugins). Defaults to empty (no HTTP imports allowed in per-request plugins).
@@ -807,6 +894,7 @@ impl Default for VlcConfig {
             vega_plugins: None,
             plugin_import_domains: Vec::new(),
             allow_per_request_plugins: false,
+            allow_google_fonts: false,
             per_request_plugin_import_domains: Vec::new(),
             default_theme: None,
             default_format_locale: None,
@@ -908,6 +996,14 @@ pub struct VgOpts {
     /// Per-request overlay plugin (inline ESM or URL). Requires `allow_per_request_plugins`.
     pub vega_plugin: Option<String>,
     pub google_fonts: Option<Vec<GoogleFontRequest>>,
+    /// Vega config object merged via `vega.mergeConfig(spec.config, config)`.
+    pub config: Option<serde_json::Value>,
+    /// Sets `spec.background` (top-level Vega property).
+    pub background: Option<String>,
+    /// Override the spec's width.
+    pub width: Option<f32>,
+    /// Override the spec's height.
+    pub height: Option<f32>,
 }
 
 impl VgOpts {
@@ -919,6 +1015,19 @@ impl VgOpts {
             serde_json::Value::String(renderer.to_string()),
         );
 
+        if let Some(config) = &self.config {
+            opts_map.insert("config".to_string(), config.clone());
+        }
+        if let Some(w) = self.width {
+            if let Some(n) = serde_json::Number::from_f64(w as f64) {
+                opts_map.insert("width".to_string(), serde_json::Value::Number(n));
+            }
+        }
+        if let Some(h) = self.height {
+            if let Some(n) = serde_json::Number::from_f64(h as f64) {
+                opts_map.insert("height".to_string(), serde_json::Value::Number(n));
+            }
+        }
         if let Some(format_locale) = &self.format_locale {
             opts_map.insert("formatLocale".to_string(), format_locale.as_object()?);
         }
@@ -1016,6 +1125,12 @@ pub struct VlOpts {
     pub google_fonts: Option<Vec<GoogleFontRequest>>,
     /// Per-request overlay plugin (inline ESM or URL). Requires `allow_per_request_plugins`.
     pub vega_plugin: Option<String>,
+    /// Sets `spec.background` before Vega-Lite compilation.
+    pub background: Option<String>,
+    /// Override the spec's width.
+    pub width: Option<f32>,
+    /// Override the spec's height.
+    pub height: Option<f32>,
 }
 
 /// Options specific to SVG output format.
@@ -1058,6 +1173,95 @@ pub struct JpegOpts {
 #[derive(Debug, Clone, Default)]
 pub struct PdfOpts {}
 
+/// Options specific to URL output format.
+#[derive(Debug, Clone, Default)]
+pub struct UrlOpts {
+    pub fullscreen: bool,
+}
+
+/// Log level for entries captured during Vega/VL evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Error => write!(f, "ERROR"),
+            LogLevel::Warn => write!(f, "WARN"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Debug => write!(f, "DEBUG"),
+        }
+    }
+}
+
+/// A log entry captured during Vega/VL evaluation.
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub level: LogLevel,
+    pub message: String,
+}
+
+/// Output from a Vega-Lite → Vega compilation.
+#[derive(Debug)]
+pub struct VegaOutput {
+    pub spec: serde_json::Value,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from an SVG conversion.
+#[derive(Debug)]
+pub struct SvgOutput {
+    pub svg: String,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from a PNG conversion.
+#[derive(Debug)]
+pub struct PngOutput {
+    pub data: Vec<u8>,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from a JPEG conversion.
+#[derive(Debug)]
+pub struct JpegOutput {
+    pub data: Vec<u8>,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from a PDF conversion.
+#[derive(Debug)]
+pub struct PdfOutput {
+    pub data: Vec<u8>,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from an HTML conversion.
+#[derive(Debug)]
+pub struct HtmlOutput {
+    pub html: String,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from a scenegraph extraction.
+#[derive(Debug)]
+pub struct ScenegraphOutput {
+    pub scenegraph: serde_json::Value,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Output from a scenegraph msgpack extraction.
+#[derive(Debug)]
+pub struct ScenegraphMsgpackOutput {
+    pub data: Vec<u8>,
+    pub logs: Vec<LogEntry>,
+}
+
 impl VlOpts {
     pub fn to_embed_opts(&self, renderer: Renderer) -> Result<serde_json::Value, AnyError> {
         let mut opts_map = serde_json::Map::new();
@@ -1078,6 +1282,16 @@ impl VlOpts {
             opts_map.insert("config".to_string(), config.clone());
         }
 
+        if let Some(w) = self.width {
+            if let Some(n) = serde_json::Number::from_f64(w as f64) {
+                opts_map.insert("width".to_string(), serde_json::Value::Number(n));
+            }
+        }
+        if let Some(h) = self.height {
+            if let Some(n) = serde_json::Number::from_f64(h as f64) {
+                opts_map.insert("height".to_string(), serde_json::Value::Number(n));
+            }
+        }
         if let Some(format_locale) = &self.format_locale {
             opts_map.insert("formatLocale".to_string(), format_locale.as_object()?);
         }
@@ -1350,6 +1564,10 @@ pub(crate) struct InnerVlConverter {
     /// Set when a plugin fails during init_vega(). Subsequent commands
     /// return this error immediately (no retry on the tainted isolate).
     plugin_init_error: Option<String>,
+    /// Log entries captured during the most recent conversion.
+    /// Populated by `emit_js_log_messages()`, taken by `std::mem::take` before
+    /// returning typed output structs.
+    pub(crate) last_log_entries: Vec<LogEntry>,
 }
 
 impl InnerVlConverter {
@@ -1432,20 +1650,26 @@ impl InnerVlConverter {
         }
     }
 
-    /// Start a conversion timeout timer. Returns `None` if the timeout is
-    /// disabled (0). The returned `ConversionTimer` must be cancelled after
-    /// the conversion completes by calling `cancel_conversion_timer()`.
-    fn start_conversion_timer(&mut self) -> Option<ConversionTimer> {
-        self.start_conversion_timer_with_duration(std::time::Duration::from_secs(
-            self.ctx.config.max_v8_execution_time_secs,
-        ))
+    /// Start a conversion timeout timer that also watches for caller disconnect.
+    /// Returns `None` if the timeout is disabled (0). The returned
+    /// `ConversionTimer` must be cancelled after the conversion completes by
+    /// calling `cancel_conversion_timer()`.
+    fn start_conversion_timer(
+        &mut self,
+        caller_gone: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Option<ConversionTimer> {
+        self.start_conversion_timer_with_duration(
+            std::time::Duration::from_secs(self.ctx.config.max_v8_execution_time_secs),
+            caller_gone,
+        )
     }
 
-    /// Start a conversion timeout timer with an explicit duration. Used by
-    /// ephemeral workers that subtract already-elapsed time from the budget.
+    /// Start a conversion timeout timer with an explicit duration. Also monitors
+    /// `caller_gone` so V8 can be terminated early if the caller disconnects.
     fn start_conversion_timer_with_duration(
         &mut self,
         duration: std::time::Duration,
+        caller_gone: Arc<std::sync::atomic::AtomicBool>,
     ) -> Option<ConversionTimer> {
         if duration.is_zero() {
             return None;
@@ -1453,12 +1677,30 @@ impl InnerVlConverter {
         let timeout_hit = self.timeout_hit.clone();
         let handle = self.worker.js_runtime.v8_isolate().thread_safe_handle();
         let (cancel_tx, cancel_rx) = std::sync::mpsc::channel::<()>();
+        let poll_interval = std::time::Duration::from_millis(50);
         let thread = std::thread::spawn(move || {
-            if let Err(std::sync::mpsc::RecvTimeoutError::Timeout) =
-                cancel_rx.recv_timeout(duration)
-            {
-                timeout_hit.store(true, std::sync::atomic::Ordering::Release);
-                handle.terminate_execution();
+            let deadline = std::time::Instant::now() + duration;
+            loop {
+                // Check if the conversion finished normally (Ok = explicit cancel,
+                // Disconnected = cancel_tx dropped in cancel_conversion_timer)
+                match cancel_rx.try_recv() {
+                    Ok(()) | Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                }
+                // Check if the caller disconnected
+                if caller_gone.load(std::sync::atomic::Ordering::Acquire) {
+                    timeout_hit.store(true, std::sync::atomic::Ordering::Release);
+                    handle.terminate_execution();
+                    return;
+                }
+                // Check if the deadline expired
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    timeout_hit.store(true, std::sync::atomic::Ordering::Release);
+                    handle.terminate_execution();
+                    return;
+                }
+                std::thread::sleep(poll_interval.min(remaining));
             }
         });
         Some(ConversionTimer { cancel_tx, thread })
@@ -1738,20 +1980,20 @@ function buildLoader(errors) {
     return loader;
 }
 
-function vegaToView(vgSpec, errors) {
-    let runtime = vega.parse(vgSpec);
+function vegaToView(vgSpec, config, errors) {
+    let runtime = vega.parse(vgSpec, config || {});
     const loader = buildLoader(errors);
     return new vega.View(runtime, {renderer: 'none', loader, logLevel: vega.Debug, logger: logCollector});
 }
 
-function vegaToSvg(vgSpec, formatLocale, timeFormatLocale, errors) {
+function vegaToSvg(vgSpec, formatLocale, timeFormatLocale, config, errors) {
     if (formatLocale != null) {
         vega.formatLocale(formatLocale);
     }
     if (timeFormatLocale != null) {
         vega.timeFormatLocale(timeFormatLocale);
     }
-    let view = vegaToView(vgSpec, errors);
+    let view = vegaToView(vgSpec, config, errors);
     let svgPromise = view.runAsync().then(() => {
         try {
             // Workaround for https://github.com/vega/vega/issues/3481
@@ -1833,14 +2075,14 @@ function cloneScenegraph(obj) {
     return clone;
 }
 
-function vegaToScenegraph(vgSpec, formatLocale, timeFormatLocale, errors) {
+function vegaToScenegraph(vgSpec, formatLocale, timeFormatLocale, config, errors) {
     if (formatLocale != null) {
         vega.formatLocale(formatLocale);
     }
     if (timeFormatLocale != null) {
         vega.timeFormatLocale(timeFormatLocale);
     }
-    let view = vegaToView(vgSpec, errors);
+    let view = vegaToView(vgSpec, config, errors);
     let scenegraphPromise = view.runAsync().then(() => {
         try {
             // Workaround for https://github.com/vega/vega/issues/3481
@@ -1873,7 +2115,7 @@ function vegaToScenegraph(vgSpec, formatLocale, timeFormatLocale, errors) {
     return scenegraphPromise
 }
 
-function vegaToCanvas(vgSpec, formatLocale, timeFormatLocale, scale, errors) {
+function vegaToCanvas(vgSpec, formatLocale, timeFormatLocale, scale, config, errors) {
     if (formatLocale != null) {
         vega.formatLocale(formatLocale);
     }
@@ -1881,7 +2123,7 @@ function vegaToCanvas(vgSpec, formatLocale, timeFormatLocale, scale, errors) {
         vega.timeFormatLocale(timeFormatLocale);
     }
 
-    let view = vegaToView(vgSpec, errors);
+    let view = vegaToView(vgSpec, config, errors);
     let canvasPromise = view.runAsync().then(() => {
         try {
             // Workaround for https://github.com/vega/vega/issues/3481
@@ -2070,17 +2312,17 @@ function compileVegaLite_{ver_name}(vlSpec, config, theme) {{
 
 function vegaLiteToSvg_{ver_name}(vlSpec, config, theme, formatLocale, timeFormatLocale, errors) {{
     let vgSpec = compileVegaLite_{ver_name}(vlSpec, config, theme);
-    return vegaToSvg(vgSpec, formatLocale, timeFormatLocale, errors)
+    return vegaToSvg(vgSpec, formatLocale, timeFormatLocale, null, errors)
 }}
 
 function vegaLiteToScenegraph_{ver_name}(vlSpec, config, theme, formatLocale, timeFormatLocale, errors) {{
     let vgSpec = compileVegaLite_{ver_name}(vlSpec, config, theme);
-    return vegaToScenegraph(vgSpec, formatLocale, timeFormatLocale, errors)
+    return vegaToScenegraph(vgSpec, formatLocale, timeFormatLocale, null, errors)
 }}
 
 function vegaLiteToCanvas_{ver_name}(vlSpec, config, theme, formatLocale, timeFormatLocale, scale, errors) {{
     let vgSpec = compileVegaLite_{ver_name}(vlSpec, config, theme);
-    return vegaToCanvas(vgSpec, formatLocale, timeFormatLocale, scale, errors)
+    return vegaToCanvas(vgSpec, formatLocale, timeFormatLocale, scale, null, errors)
 }}
 "#,
                 ver_name = format!("{:?}", vl_version),
@@ -2222,6 +2464,7 @@ function vegaLiteToCanvas_{ver_name}(vlSpec, config, theme, formatLocale, timeFo
             heap_limit_data,
             timeout_hit: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             plugin_init_error: None,
+            last_log_entries: Vec::new(),
         };
 
         Ok(this)
@@ -2276,6 +2519,7 @@ function vegaLiteToCanvas_{ver_name}(vlSpec, config, theme, formatLocale, timeFo
     }
 
     async fn emit_js_log_messages(&mut self) {
+        self.last_log_entries.clear();
         let json = match self
             .execute_script_to_string("_collapsedLogMessages()")
             .await
@@ -2300,10 +2544,34 @@ function vegaLiteToCanvas_{ver_name}(vlSpec, config, theme, formatLocale, timeFo
             let level = entry.get("level").and_then(|v| v.as_str()).unwrap_or("");
             let msg = entry.get("msg").and_then(|v| v.as_str()).unwrap_or("");
             match level {
-                "error" => vl_error!("{}", msg),
-                "warn" => vl_warn!("{}", msg),
-                "info" => vl_info!("{}", msg),
-                "debug" => vl_debug!("{}", msg),
+                "error" => {
+                    vl_error!("{}", msg);
+                    self.last_log_entries.push(LogEntry {
+                        level: LogLevel::Error,
+                        message: msg.to_string(),
+                    });
+                }
+                "warn" => {
+                    vl_warn!("{}", msg);
+                    self.last_log_entries.push(LogEntry {
+                        level: LogLevel::Warn,
+                        message: msg.to_string(),
+                    });
+                }
+                "info" => {
+                    vl_info!("{}", msg);
+                    self.last_log_entries.push(LogEntry {
+                        level: LogLevel::Info,
+                        message: msg.to_string(),
+                    });
+                }
+                "debug" => {
+                    vl_debug!("{}", msg);
+                    self.last_log_entries.push(LogEntry {
+                        level: LogLevel::Debug,
+                        message: msg.to_string(),
+                    });
+                }
                 _ => {}
             }
         }
@@ -2313,12 +2581,18 @@ function vegaLiteToCanvas_{ver_name}(vlSpec, config, theme, formatLocale, timeFo
         &mut self,
         vl_spec: impl Into<ValueOrString>,
         vl_opts: VlOpts,
-    ) -> Result<serde_json::Value, AnyError> {
+    ) -> Result<VegaOutput, AnyError> {
         self.init_vega().await?;
         self.init_vl_version(&vl_opts.vl_version).await?;
         let config = vl_opts.config.clone().unwrap_or(serde_json::Value::Null);
 
-        let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vl_spec.into())?;
+        let vl_spec = apply_spec_overrides(
+            vl_spec.into(),
+            &vl_opts.background,
+            vl_opts.width,
+            vl_opts.height,
+        )?;
+        let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vl_spec)?;
         let config_arg = JsonArgGuard::from_value(&self.transfer_state, config)?;
 
         let theme_arg = match &vl_opts.theme {
@@ -2341,19 +2615,26 @@ compileVegaLite_{ver_name:?}(
             theme_arg = theme_arg,
         );
 
-        let value = self.execute_script_to_json(&code).await?;
+        let spec = self.execute_script_to_json(&code).await?;
         self.emit_js_log_messages().await;
-        Ok(value)
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(VegaOutput { spec, logs })
     }
 
     pub async fn vegalite_to_svg(
         &mut self,
         vl_spec: impl Into<ValueOrString>,
         vl_opts: VlOpts,
-    ) -> Result<String, AnyError> {
+    ) -> Result<SvgOutput, AnyError> {
         self.init_vega().await?;
         self.init_vl_version(&vl_opts.vl_version).await?;
 
+        let vl_spec = apply_spec_overrides(
+            vl_spec.into(),
+            &vl_opts.background,
+            vl_opts.width,
+            vl_opts.height,
+        )?;
         let config = vl_opts.config.clone().unwrap_or(serde_json::Value::Null);
 
         let format_locale = match vl_opts.format_locale {
@@ -2366,7 +2647,7 @@ compileVegaLite_{ver_name:?}(
             Some(fl) => fl.as_object()?,
         };
 
-        let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vl_spec.into())?;
+        let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vl_spec)?;
         let config_arg = JsonArgGuard::from_value(&self.transfer_state, config)?;
         let format_locale_arg = JsonArgGuard::from_value(&self.transfer_state, format_locale)?;
         let time_format_locale_arg =
@@ -2417,18 +2698,24 @@ vegaLiteToSvg_{ver_name:?}(
         if !access_errors.is_empty() {
             bail!("{access_errors}");
         }
-        let value = self.execute_script_to_string("svg").await?;
-        Ok(value)
+        let svg = self.execute_script_to_string("svg").await?;
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(SvgOutput { svg, logs })
     }
 
     pub async fn vegalite_to_scenegraph_msgpack(
         &mut self,
         vl_spec: impl Into<ValueOrString>,
         vl_opts: VlOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<ScenegraphMsgpackOutput, AnyError> {
         self.init_vega().await?;
         self.init_vl_version(&vl_opts.vl_version).await?;
-        let vl_spec = vl_spec.into();
+        let vl_spec = apply_spec_overrides(
+            vl_spec.into(),
+            &vl_opts.background,
+            vl_opts.width,
+            vl_opts.height,
+        )?;
 
         let config = vl_opts.config.clone().unwrap_or(serde_json::Value::Null);
         let format_locale = match vl_opts.format_locale {
@@ -2493,28 +2780,40 @@ vegaLiteToScenegraph_{ver_name:?}(
         if !access_errors.is_empty() {
             bail!("{access_errors}");
         }
-        result.take_result()
+        let data = result.take_result()?;
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(ScenegraphMsgpackOutput { data, logs })
     }
 
     pub async fn vegalite_to_scenegraph(
         &mut self,
         vl_spec: impl Into<ValueOrString>,
         vl_opts: VlOpts,
-    ) -> Result<serde_json::Value, AnyError> {
-        let sg_msgpack = self
+    ) -> Result<ScenegraphOutput, AnyError> {
+        let sg_output = self
             .vegalite_to_scenegraph_msgpack(vl_spec, vl_opts)
             .await?;
-        let value: serde_json::Value = rmp_serde::from_slice(&sg_msgpack)
+        let scenegraph: serde_json::Value = rmp_serde::from_slice(&sg_output.data)
             .map_err(|err| anyhow!("Failed to decode MessagePack scenegraph: {err}"))?;
-        Ok(value)
+        Ok(ScenegraphOutput {
+            scenegraph,
+            logs: sg_output.logs,
+        })
     }
 
     pub async fn vega_to_svg(
         &mut self,
         vg_spec: impl Into<ValueOrString>,
         vg_opts: VgOpts,
-    ) -> Result<String, AnyError> {
+    ) -> Result<SvgOutput, AnyError> {
         self.init_vega().await?;
+
+        let vg_spec = apply_spec_overrides(
+            vg_spec.into(),
+            &vg_opts.background,
+            vg_opts.width,
+            vg_opts.height,
+        )?;
 
         let format_locale = match vg_opts.format_locale {
             None => serde_json::Value::Null,
@@ -2526,10 +2825,13 @@ vegaLiteToScenegraph_{ver_name:?}(
             Some(fl) => fl.as_object()?,
         };
 
-        let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vg_spec.into())?;
+        let config_value = vg_opts.config.unwrap_or(serde_json::Value::Null);
+
+        let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vg_spec)?;
         let format_locale_arg = JsonArgGuard::from_value(&self.transfer_state, format_locale)?;
         let time_format_locale_arg =
             JsonArgGuard::from_value(&self.transfer_state, time_format_locale)?;
+        let config_arg = JsonArgGuard::from_value(&self.transfer_state, config_value)?;
 
         let code = format!(
             r#"
@@ -2540,6 +2842,7 @@ vegaToSvg(
     JSON.parse(op_get_json_arg({arg_id})),
     JSON.parse(op_get_json_arg({format_locale_id})),
     JSON.parse(op_get_json_arg({time_format_locale_id})),
+    JSON.parse(op_get_json_arg({config_id})),
     errors,
 ).then((result) => {{
     if (errors != null && errors.length > 0) {{
@@ -2551,6 +2854,7 @@ vegaToSvg(
             arg_id = spec_arg.id(),
             format_locale_id = format_locale_arg.id(),
             time_format_locale_id = time_format_locale_arg.id(),
+            config_id = config_arg.id(),
         );
         self.worker.js_runtime.execute_script("ext:<anon>", code)?;
         self.worker
@@ -2567,17 +2871,23 @@ vegaToSvg(
         if !access_errors.is_empty() {
             bail!("{access_errors}");
         }
-        let value = self.execute_script_to_string("svg").await?;
-        Ok(value)
+        let svg = self.execute_script_to_string("svg").await?;
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(SvgOutput { svg, logs })
     }
 
     pub async fn vega_to_scenegraph_msgpack(
         &mut self,
         vg_spec: impl Into<ValueOrString>,
         vg_opts: VgOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<ScenegraphMsgpackOutput, AnyError> {
         self.init_vega().await?;
-        let vg_spec = vg_spec.into();
+        let vg_spec = apply_spec_overrides(
+            vg_spec.into(),
+            &vg_opts.background,
+            vg_opts.width,
+            vg_opts.height,
+        )?;
         let format_locale = match vg_opts.format_locale {
             None => serde_json::Value::Null,
             Some(fl) => fl.as_object()?,
@@ -2588,10 +2898,12 @@ vegaToSvg(
             Some(fl) => fl.as_object()?,
         };
 
+        let config_value = vg_opts.config.unwrap_or(serde_json::Value::Null);
         let spec_arg = JsonArgGuard::from_spec(&self.transfer_state, vg_spec)?;
         let format_locale_arg = JsonArgGuard::from_value(&self.transfer_state, format_locale)?;
         let time_format_locale_arg =
             JsonArgGuard::from_value(&self.transfer_state, time_format_locale)?;
+        let config_arg = JsonArgGuard::from_value(&self.transfer_state, config_value)?;
         let result = MsgpackResultGuard::new(&self.transfer_state)?;
 
         let code = format!(
@@ -2602,6 +2914,7 @@ vegaToScenegraph(
     JSON.parse(op_get_json_arg({arg_id})),
     JSON.parse(op_get_json_arg({format_locale_id})),
     JSON.parse(op_get_json_arg({time_format_locale_id})),
+    JSON.parse(op_get_json_arg({config_id})),
     errors,
 ).then((result) => {{
     if (errors != null && errors.length > 0) {{
@@ -2613,6 +2926,7 @@ vegaToScenegraph(
             arg_id = spec_arg.id(),
             format_locale_id = format_locale_arg.id(),
             time_format_locale_id = time_format_locale_arg.id(),
+            config_id = config_arg.id(),
             result_id = result.id(),
         );
         self.worker.js_runtime.execute_script("ext:<anon>", code)?;
@@ -2630,18 +2944,23 @@ vegaToScenegraph(
         if !access_errors.is_empty() {
             bail!("{access_errors}");
         }
-        result.take_result()
+        let data = result.take_result()?;
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(ScenegraphMsgpackOutput { data, logs })
     }
 
     pub async fn vega_to_scenegraph(
         &mut self,
         vg_spec: impl Into<ValueOrString>,
         vg_opts: VgOpts,
-    ) -> Result<serde_json::Value, AnyError> {
-        let sg_msgpack = self.vega_to_scenegraph_msgpack(vg_spec, vg_opts).await?;
-        let value: serde_json::Value = rmp_serde::from_slice(&sg_msgpack)
+    ) -> Result<ScenegraphOutput, AnyError> {
+        let sg_output = self.vega_to_scenegraph_msgpack(vg_spec, vg_opts).await?;
+        let scenegraph: serde_json::Value = rmp_serde::from_slice(&sg_output.data)
             .map_err(|err| anyhow!("Failed to decode MessagePack scenegraph: {err}"))?;
-        Ok(value)
+        Ok(ScenegraphOutput {
+            scenegraph,
+            logs: sg_output.logs,
+        })
     }
 
     pub async fn get_local_tz(&mut self) -> Result<Option<String>, AnyError> {
@@ -2704,8 +3023,17 @@ delete themes.default
         vg_opts: VgOpts,
         scale: f32,
         ppi: f32,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<PngOutput, AnyError> {
         self.init_vega().await?;
+
+        let vg_spec = apply_spec_overrides(
+            ValueOrString::Value(vg_spec.clone()),
+            &vg_opts.background,
+            vg_opts.width,
+            vg_opts.height,
+        )?
+        .to_value()?;
+
         let format_locale = match vg_opts.format_locale {
             None => serde_json::Value::Null,
             Some(fl) => fl.as_object()?,
@@ -2716,10 +3044,13 @@ delete themes.default
             Some(fl) => fl.as_object()?,
         };
 
-        let spec_arg = JsonArgGuard::from_value(&self.transfer_state, vg_spec.clone())?;
+        let config_value = vg_opts.config.unwrap_or(serde_json::Value::Null);
+
+        let spec_arg = JsonArgGuard::from_value(&self.transfer_state, vg_spec)?;
         let format_locale_arg = JsonArgGuard::from_value(&self.transfer_state, format_locale)?;
         let time_format_locale_arg =
             JsonArgGuard::from_value(&self.transfer_state, time_format_locale)?;
+        let config_arg = JsonArgGuard::from_value(&self.transfer_state, config_value)?;
 
         let code = format!(
             r#"
@@ -2731,6 +3062,7 @@ vegaToCanvas(
     JSON.parse(op_get_json_arg({format_locale_id})),
     JSON.parse(op_get_json_arg({time_format_locale_id})),
     {scale},
+    JSON.parse(op_get_json_arg({config_id})),
     errors,
 ).then((canvas) => {{
     if (errors != null && errors.length > 0) {{
@@ -2742,6 +3074,7 @@ vegaToCanvas(
             arg_id = spec_arg.id(),
             format_locale_id = format_locale_arg.id(),
             time_format_locale_id = time_format_locale_arg.id(),
+            config_id = config_arg.id(),
         );
         self.worker.js_runtime.execute_script("ext:<anon>", code)?;
         self.worker
@@ -2758,8 +3091,9 @@ vegaToCanvas(
         if !access_errors.is_empty() {
             bail!("{access_errors}");
         }
-        let png_data = self.execute_script_to_bytes("canvasPngData").await?;
-        Ok(png_data)
+        let data = self.execute_script_to_bytes("canvasPngData").await?;
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(PngOutput { data, logs })
     }
 
     pub async fn vegalite_to_png(
@@ -2768,7 +3102,7 @@ vegaToCanvas(
         vl_opts: VlOpts,
         scale: f32,
         ppi: f32,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<PngOutput, AnyError> {
         self.init_vega().await?;
         self.init_vl_version(&vl_opts.vl_version).await?;
 
@@ -2836,8 +3170,9 @@ vegaLiteToCanvas_{ver_name:?}(
         if !access_errors.is_empty() {
             bail!("{access_errors}");
         }
-        let png_data = self.execute_script_to_bytes("canvasPngData").await?;
-        Ok(png_data)
+        let data = self.execute_script_to_bytes("canvasPngData").await?;
+        let logs = std::mem::take(&mut self.last_log_entries);
+        Ok(PngOutput { data, logs })
     }
 
     fn parse_svg_with_worker_options(
@@ -2912,9 +3247,14 @@ vegaLiteToCanvas_{ver_name:?}(
         scale: f32,
         quality: Option<u8>,
         policy: ImageAccessPolicy,
-    ) -> Result<Vec<u8>, AnyError> {
-        let svg = self.vega_to_svg(vg_spec, vg_opts).await?;
-        self.svg_to_jpeg_with_worker_options(&svg, scale, quality, &policy)
+    ) -> Result<JpegOutput, AnyError> {
+        let svg_output = self.vega_to_svg(vg_spec, vg_opts).await?;
+        let data =
+            self.svg_to_jpeg_with_worker_options(&svg_output.svg, scale, quality, &policy)?;
+        Ok(JpegOutput {
+            data,
+            logs: svg_output.logs,
+        })
     }
 
     pub async fn vegalite_to_jpeg(
@@ -2924,9 +3264,14 @@ vegaLiteToCanvas_{ver_name:?}(
         scale: f32,
         quality: Option<u8>,
         policy: ImageAccessPolicy,
-    ) -> Result<Vec<u8>, AnyError> {
-        let svg = self.vegalite_to_svg(vl_spec, vl_opts).await?;
-        self.svg_to_jpeg_with_worker_options(&svg, scale, quality, &policy)
+    ) -> Result<JpegOutput, AnyError> {
+        let svg_output = self.vegalite_to_svg(vl_spec, vl_opts).await?;
+        let data =
+            self.svg_to_jpeg_with_worker_options(&svg_output.svg, scale, quality, &policy)?;
+        Ok(JpegOutput {
+            data,
+            logs: svg_output.logs,
+        })
     }
 
     pub async fn vega_to_pdf(
@@ -2934,9 +3279,13 @@ vegaLiteToCanvas_{ver_name:?}(
         vg_spec: ValueOrString,
         vg_opts: VgOpts,
         policy: ImageAccessPolicy,
-    ) -> Result<Vec<u8>, AnyError> {
-        let svg = self.vega_to_svg(vg_spec, vg_opts).await?;
-        self.svg_to_pdf_with_worker_options(&svg, &policy)
+    ) -> Result<PdfOutput, AnyError> {
+        let svg_output = self.vega_to_svg(vg_spec, vg_opts).await?;
+        let data = self.svg_to_pdf_with_worker_options(&svg_output.svg, &policy)?;
+        Ok(PdfOutput {
+            data,
+            logs: svg_output.logs,
+        })
     }
 
     pub async fn vegalite_to_pdf(
@@ -2944,9 +3293,13 @@ vegaLiteToCanvas_{ver_name:?}(
         vl_spec: ValueOrString,
         vl_opts: VlOpts,
         policy: ImageAccessPolicy,
-    ) -> Result<Vec<u8>, AnyError> {
-        let svg = self.vegalite_to_svg(vl_spec, vl_opts).await?;
-        self.svg_to_pdf_with_worker_options(&svg, &policy)
+    ) -> Result<PdfOutput, AnyError> {
+        let svg_output = self.vegalite_to_svg(vl_spec, vl_opts).await?;
+        let data = self.svg_to_pdf_with_worker_options(&svg_output.svg, &policy)?;
+        Ok(PdfOutput {
+            data,
+            logs: svg_output.logs,
+        })
     }
 
     /// Resolve Google Fonts requests on the worker thread using the async API.
@@ -3399,7 +3752,7 @@ pub(crate) struct VlConverterInner {
 ///   }
 /// }"#).unwrap();
 ///
-/// let vega_spec = futures::executor::block_on(
+/// let vega_output = futures::executor::block_on(
 ///     converter.vegalite_to_vega(
 ///         vl_spec,
 ///         VlOpts {
@@ -3409,7 +3762,7 @@ pub(crate) struct VlConverterInner {
 ///     )
 /// ).expect("Failed to perform Vega-Lite to Vega conversion");
 ///
-/// println!("{}", vega_spec);
+/// println!("{}", vega_output.spec);
 /// ```
 #[derive(Clone)]
 pub struct VlConverter {
@@ -3505,16 +3858,20 @@ impl VlConverter {
         Ok(sender)
     }
 
-    async fn send_work_with_retry(&self, work: WorkFn) -> Result<(), AnyError> {
+    async fn send_work_with_retry(
+        &self,
+        work: WorkFn,
+        caller_gone: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Result<(), AnyError> {
         let (sender, ticket) = self.get_or_spawn_sender()?;
-        let queued = QueuedWork::new(work, ticket);
+        let queued = QueuedWork::new(work, ticket, caller_gone.clone());
         match sender.send(queued).await {
             Ok(()) => Ok(()),
             Err(tokio::sync::mpsc::error::SendError(queued)) => {
-                let (work, _old_ticket) = queued.into_parts();
+                let (work, _old_ticket, _) = queued.into_parts();
                 let (sender, ticket) = self.get_or_spawn_sender()?;
                 sender
-                    .send(QueuedWork::new(work, ticket))
+                    .send(QueuedWork::new(work, ticket, caller_gone))
                     .await
                     .map_err(|err| anyhow!("Failed to send request after retry: {err}"))
             }
@@ -3530,6 +3887,7 @@ impl VlConverter {
             + Send
             + 'static,
     ) -> Result<R, AnyError> {
+        let caller_gone = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (resp_tx, resp_rx) = oneshot::channel::<Result<R, AnyError>>();
         let boxed_work: WorkFn = Box::new(move |inner| {
             Box::pin(async move {
@@ -3545,12 +3903,24 @@ impl VlConverter {
             })
         });
 
-        self.send_work_with_retry(boxed_work).await?;
-        resp_rx.await.map_err(|e| anyhow!("Worker dropped: {e}"))?
+        self.send_work_with_retry(boxed_work, caller_gone.clone())
+            .await?;
+
+        // Guard signals caller_gone on drop (HTTP timeout / client disconnect).
+        // Disarmed on normal completion so the timer thread doesn't spuriously
+        // terminate V8.
+        let mut guard = CallerGoneGuard::new(caller_gone);
+        let result = resp_rx.await.map_err(|e| anyhow!("Worker dropped: {e}"));
+        guard.disarm();
+        result?
     }
 
     /// Run a conversion on an ephemeral worker with a per-request plugin.
-    fn run_on_ephemeral_worker<R: Send + 'static>(
+    ///
+    /// Uses a oneshot channel (like `run_on_worker`) so the caller awaits a
+    /// future. If that future is dropped (e.g. HTTP disconnect), the
+    /// `CallerGoneGuard` signals the timer thread to terminate V8.
+    async fn run_on_ephemeral_worker<R: Send + 'static>(
         &self,
         plugin_source: String,
         work: impl FnOnce(
@@ -3585,14 +3955,24 @@ impl VlConverter {
         });
 
         let font_baseline = get_font_baseline_snapshot()?;
+        let caller_gone = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let caller_gone_inner = caller_gone.clone();
+        let (resp_tx, resp_rx) = oneshot::channel::<Result<R, AnyError>>();
 
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .map_err(|e| anyhow!("Failed to build ephemeral worker runtime: {e}"))?;
+                .map_err(|e| anyhow!("Failed to build ephemeral worker runtime: {e}"));
+            let rt = match rt {
+                Ok(rt) => rt,
+                Err(e) => {
+                    let _ = resp_tx.send(Err(e));
+                    return;
+                }
+            };
             let local = tokio::task::LocalSet::new();
-            local.block_on(&rt, async move {
+            let result = local.block_on(&rt, async move {
                 let timeout_secs = ctx.config.max_v8_execution_time_secs;
                 let deadline = if timeout_secs > 0 {
                     Some(std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs))
@@ -3634,13 +4014,12 @@ impl VlConverter {
                 // Arm the V8 watchdog timer with remaining budget
                 let timer = if let Some(deadline) = deadline {
                     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                    inner.start_conversion_timer_with_duration(remaining)
+                    inner.start_conversion_timer_with_duration(remaining, caller_gone_inner)
                 } else {
                     None
                 };
 
                 // Run init, plugin load, and conversion under the timer.
-                // Use a closure so we always clean up the timer on all paths.
                 let result = async {
                     inner.init_vega().await?;
                     let plugin_index = inner.ctx.resolved_plugins.as_ref().map_or(0, |p| p.len());
@@ -3660,10 +4039,16 @@ impl VlConverter {
                 let result = inner.annotate_timeout_error(result);
                 inner.reset_timeout_if_needed();
                 result
-            })
-        })
-        .join()
-        .map_err(|_| anyhow!("Ephemeral worker thread panicked"))?
+            });
+            let _ = resp_tx.send(result);
+        });
+
+        let mut guard = CallerGoneGuard::new(caller_gone);
+        let result = resp_rx
+            .await
+            .map_err(|_| anyhow!("Ephemeral worker thread panicked"));
+        guard.disarm();
+        result?
     }
 
     fn should_preprocess_fonts(&self) -> bool {
@@ -3679,7 +4064,7 @@ impl VlConverter {
         &self,
         vl_spec: &ValueOrString,
         vl_opts: &VlOpts,
-    ) -> Result<Option<(serde_json::Value, VgOpts)>, AnyError> {
+    ) -> Result<Option<(serde_json::Value, VgOpts, Vec<LogEntry>)>, AnyError> {
         if !self.should_preprocess_fonts() {
             return Ok(None);
         }
@@ -3688,10 +4073,16 @@ impl VlConverter {
             time_format_locale: vl_opts.time_format_locale.clone(),
             google_fonts: vl_opts.google_fonts.clone(),
             vega_plugin: vl_opts.vega_plugin.clone(),
+            config: vl_opts.config.clone(),
+            background: vl_opts.background.clone(),
+            width: vl_opts.width,
+            height: vl_opts.height,
         };
-        let vega_spec = self
+        let vega_output = self
             .vegalite_to_vega(vl_spec.clone(), vl_opts.clone())
             .await?;
+        let vega_spec = vega_output.spec;
+        let compile_logs = vega_output.logs;
         let auto_requests = preprocess_fonts(
             &vega_spec,
             self.inner.config.auto_google_fonts,
@@ -3704,7 +4095,7 @@ impl VlConverter {
                 .get_or_insert_with(Vec::new)
                 .extend(auto_requests);
         }
-        Ok(Some((vega_spec, vg_opts)))
+        Ok(Some((vega_spec, vg_opts, compile_logs)))
     }
 
     /// If font preprocessing is enabled, parse the Vega spec and process missing fonts.
@@ -3789,7 +4180,7 @@ impl VlConverter {
         &self,
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
-    ) -> Result<serde_json::Value, AnyError> {
+    ) -> Result<VegaOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let vl_spec = vl_spec.into();
         self.run_on_worker(move |inner| Box::pin(inner.vegalite_to_vega(vl_spec, vl_opts)))
@@ -3801,13 +4192,11 @@ impl VlConverter {
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
         svg_opts: SvgOpts,
-    ) -> Result<String, AnyError> {
+    ) -> Result<SvgOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
         let plugin = vg_opts.vega_plugin.take();
 
-        // Extract user-specified Google font families BEFORE auto-detection
-        // merges in, so classify_scenegraph_fonts treats them as explicit.
         let explicit_google_families: HashSet<String> = vg_opts
             .google_fonts
             .as_ref()
@@ -3822,14 +4211,15 @@ impl VlConverter {
                 .extend(auto_requests);
         }
 
-        let svg = if let Some(plugin_source) = plugin {
+        let mut output = if let Some(plugin_source) = plugin {
             self.run_on_ephemeral_worker(plugin_source, move |inner| {
                 let gf = vg_opts.google_fonts.take();
                 let inner = &mut *inner;
                 Box::pin(async move {
                     with_font_overlay!(inner, gf, inner.vega_to_svg(vg_spec, vg_opts).await)
                 })
-            })?
+            })
+            .await?
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vg_opts.google_fonts.take();
@@ -3841,8 +4231,10 @@ impl VlConverter {
             .await?
         };
 
-        self.postprocess_svg(svg, &svg_opts, explicit_google_families)
-            .await
+        output.svg = self
+            .postprocess_svg(output.svg, &svg_opts, explicit_google_families)
+            .await?;
+        Ok(output)
     }
 
     /// Post-process a rendered SVG to embed fonts and/or inline images
@@ -3947,7 +4339,7 @@ impl VlConverter {
         &self,
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
-    ) -> Result<serde_json::Value, AnyError> {
+    ) -> Result<ScenegraphOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
         let auto_requests = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
@@ -3971,7 +4363,7 @@ impl VlConverter {
         &self,
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<ScenegraphMsgpackOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
         let auto_requests = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
@@ -4000,31 +4392,31 @@ impl VlConverter {
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
         svg_opts: SvgOpts,
-    ) -> Result<String, AnyError> {
+    ) -> Result<SvgOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let vl_spec = vl_spec.into();
         let plugin = vl_opts.vega_plugin.take();
 
-        // Extract user-specified Google font families before they're consumed
         let explicit_google_families: HashSet<String> = vl_opts
             .google_fonts
             .as_ref()
             .map(|reqs| reqs.iter().map(|r| r.family.clone()).collect())
             .unwrap_or_default();
 
-        let svg = if let Some((vega_spec, mut vg_opts)) = self
+        let mut output = if let Some((vega_spec, mut vg_opts, compile_logs)) = self
             .maybe_compile_vl_with_preprocessed_fonts(&vl_spec, &vl_opts)
             .await?
         {
             let vg_spec: ValueOrString = vega_spec.into();
-            if let Some(plugin_source) = plugin {
+            let mut output = if let Some(plugin_source) = plugin {
                 self.run_on_ephemeral_worker(plugin_source, move |inner| {
                     let gf = vg_opts.google_fonts.take();
                     let inner = &mut *inner;
                     Box::pin(async move {
                         with_font_overlay!(inner, gf, inner.vega_to_svg(vg_spec, vg_opts).await)
                     })
-                })?
+                })
+                .await?
             } else {
                 self.run_on_worker(move |inner| {
                     let gf = vg_opts.google_fonts.take();
@@ -4034,7 +4426,11 @@ impl VlConverter {
                     })
                 })
                 .await?
-            }
+            };
+            let mut all_logs = compile_logs;
+            all_logs.extend(output.logs);
+            output.logs = all_logs;
+            output
         } else if let Some(plugin_source) = plugin {
             self.run_on_ephemeral_worker(plugin_source, move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4042,7 +4438,8 @@ impl VlConverter {
                 Box::pin(async move {
                     with_font_overlay!(inner, gf, inner.vegalite_to_svg(vl_spec, vl_opts).await)
                 })
-            })?
+            })
+            .await?
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4054,31 +4451,42 @@ impl VlConverter {
             .await?
         };
 
-        self.postprocess_svg(svg, &svg_opts, explicit_google_families)
-            .await
+        output.svg = self
+            .postprocess_svg(output.svg, &svg_opts, explicit_google_families)
+            .await?;
+        Ok(output)
     }
 
     pub async fn vegalite_to_scenegraph(
         &self,
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
-    ) -> Result<serde_json::Value, AnyError> {
+    ) -> Result<ScenegraphOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let vl_spec = vl_spec.into();
 
-        if let Some((vega_spec, mut vg_opts)) = self
+        if let Some((vega_spec, mut vg_opts, compile_logs)) = self
             .maybe_compile_vl_with_preprocessed_fonts(&vl_spec, &vl_opts)
             .await?
         {
             let vg_spec: ValueOrString = vega_spec.into();
-            self.run_on_worker(move |inner| {
-                let gf = vg_opts.google_fonts.take();
-                let inner = &mut *inner;
-                Box::pin(async move {
-                    with_font_overlay!(inner, gf, inner.vega_to_scenegraph(vg_spec, vg_opts).await)
+            let mut output = self
+                .run_on_worker(move |inner| {
+                    let gf = vg_opts.google_fonts.take();
+                    let inner = &mut *inner;
+                    Box::pin(async move {
+                        with_font_overlay!(
+                            inner,
+                            gf,
+                            inner.vega_to_scenegraph(vg_spec, vg_opts).await
+                        )
+                    })
                 })
-            })
-            .await
+                .await?;
+            let mut all_logs = compile_logs;
+            all_logs.extend(output.logs);
+            output.logs = all_logs;
+            Ok(output)
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4099,27 +4507,32 @@ impl VlConverter {
         &self,
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<ScenegraphMsgpackOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let vl_spec = vl_spec.into();
 
-        if let Some((vega_spec, mut vg_opts)) = self
+        if let Some((vega_spec, mut vg_opts, compile_logs)) = self
             .maybe_compile_vl_with_preprocessed_fonts(&vl_spec, &vl_opts)
             .await?
         {
             let vg_spec: ValueOrString = vega_spec.into();
-            self.run_on_worker(move |inner| {
-                let gf = vg_opts.google_fonts.take();
-                let inner = &mut *inner;
-                Box::pin(async move {
-                    with_font_overlay!(
-                        inner,
-                        gf,
-                        inner.vega_to_scenegraph_msgpack(vg_spec, vg_opts).await
-                    )
+            let mut output = self
+                .run_on_worker(move |inner| {
+                    let gf = vg_opts.google_fonts.take();
+                    let inner = &mut *inner;
+                    Box::pin(async move {
+                        with_font_overlay!(
+                            inner,
+                            gf,
+                            inner.vega_to_scenegraph_msgpack(vg_spec, vg_opts).await
+                        )
+                    })
                 })
-            })
-            .await
+                .await?;
+            let mut all_logs = compile_logs;
+            all_logs.extend(output.logs);
+            output.logs = all_logs;
+            Ok(output)
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4141,7 +4554,7 @@ impl VlConverter {
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
         png_opts: PngOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<PngOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
         let scale = png_opts.scale.unwrap_or(1.0);
@@ -4170,6 +4583,7 @@ impl VlConverter {
                     })
                 })
             })
+            .await
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vg_opts.google_fonts.take();
@@ -4192,7 +4606,7 @@ impl VlConverter {
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
         png_opts: PngOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<PngOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let vl_spec = vl_spec.into();
         let scale = png_opts.scale.unwrap_or(1.0);
@@ -4200,12 +4614,12 @@ impl VlConverter {
         let effective_scale = scale * ppi / 72.0;
         let plugin = vl_opts.vega_plugin.take();
 
-        if let Some((vega_spec, mut vg_opts)) = self
+        if let Some((vega_spec, mut vg_opts, compile_logs)) = self
             .maybe_compile_vl_with_preprocessed_fonts(&vl_spec, &vl_opts)
             .await?
         {
             let vg_spec: ValueOrString = vega_spec.into();
-            if let Some(plugin_source) = plugin {
+            let mut output = if let Some(plugin_source) = plugin {
                 self.run_on_ephemeral_worker(plugin_source, move |inner| {
                     let gf = vg_opts.google_fonts.take();
                     let inner = &mut *inner;
@@ -4218,6 +4632,7 @@ impl VlConverter {
                         })
                     })
                 })
+                .await?
             } else {
                 self.run_on_worker(move |inner| {
                     let gf = vg_opts.google_fonts.take();
@@ -4231,8 +4646,12 @@ impl VlConverter {
                         })
                     })
                 })
-                .await
-            }
+                .await?
+            };
+            let mut all_logs = compile_logs;
+            all_logs.extend(output.logs);
+            output.logs = all_logs;
+            Ok(output)
         } else if let Some(plugin_source) = plugin {
             self.run_on_ephemeral_worker(plugin_source, move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4246,6 +4665,7 @@ impl VlConverter {
                     })
                 })
             })
+            .await
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4268,7 +4688,7 @@ impl VlConverter {
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
         jpeg_opts: JpegOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<JpegOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let scale = jpeg_opts.scale.unwrap_or(1.0);
         let quality = jpeg_opts.quality;
@@ -4298,6 +4718,7 @@ impl VlConverter {
                     )
                 })
             })
+            .await
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vg_opts.google_fonts.take();
@@ -4321,7 +4742,7 @@ impl VlConverter {
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
         jpeg_opts: JpegOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<JpegOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let scale = jpeg_opts.scale.unwrap_or(1.0);
         let quality = jpeg_opts.quality;
@@ -4329,12 +4750,12 @@ impl VlConverter {
         let plugin = vl_opts.vega_plugin.take();
         let image_policy = self.image_access_policy();
 
-        if let Some((vega_spec, mut vg_opts)) = self
+        if let Some((vega_spec, mut vg_opts, compile_logs)) = self
             .maybe_compile_vl_with_preprocessed_fonts(&vl_spec, &vl_opts)
             .await?
         {
             let vg_spec: ValueOrString = vega_spec.into();
-            if let Some(plugin_source) = plugin {
+            let mut output = if let Some(plugin_source) = plugin {
                 self.run_on_ephemeral_worker(plugin_source, move |inner| {
                     let gf = vg_opts.google_fonts.take();
                     let inner = &mut *inner;
@@ -4348,6 +4769,7 @@ impl VlConverter {
                         )
                     })
                 })
+                .await?
             } else {
                 self.run_on_worker(move |inner| {
                     let gf = vg_opts.google_fonts.take();
@@ -4362,8 +4784,12 @@ impl VlConverter {
                         )
                     })
                 })
-                .await
-            }
+                .await?
+            };
+            let mut all_logs = compile_logs;
+            all_logs.extend(output.logs);
+            output.logs = all_logs;
+            Ok(output)
         } else if let Some(plugin_source) = plugin {
             self.run_on_ephemeral_worker(plugin_source, move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4378,6 +4804,7 @@ impl VlConverter {
                     )
                 })
             })
+            .await
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4401,7 +4828,7 @@ impl VlConverter {
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
         _pdf_opts: PdfOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<PdfOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
         let plugin = vg_opts.vega_plugin.take();
@@ -4427,6 +4854,7 @@ impl VlConverter {
                     )
                 })
             })
+            .await
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vg_opts.google_fonts.take();
@@ -4448,18 +4876,18 @@ impl VlConverter {
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
         _pdf_opts: PdfOpts,
-    ) -> Result<Vec<u8>, AnyError> {
+    ) -> Result<PdfOutput, AnyError> {
         self.apply_vl_defaults(&mut vl_opts);
         let vl_spec = vl_spec.into();
         let plugin = vl_opts.vega_plugin.take();
         let image_policy = self.image_access_policy();
 
-        if let Some((vega_spec, mut vg_opts)) = self
+        if let Some((vega_spec, mut vg_opts, compile_logs)) = self
             .maybe_compile_vl_with_preprocessed_fonts(&vl_spec, &vl_opts)
             .await?
         {
             let vg_spec: ValueOrString = vega_spec.into();
-            if let Some(plugin_source) = plugin {
+            let mut output = if let Some(plugin_source) = plugin {
                 self.run_on_ephemeral_worker(plugin_source, move |inner| {
                     let gf = vg_opts.google_fonts.take();
                     let inner = &mut *inner;
@@ -4471,6 +4899,7 @@ impl VlConverter {
                         )
                     })
                 })
+                .await?
             } else {
                 self.run_on_worker(move |inner| {
                     let gf = vg_opts.google_fonts.take();
@@ -4483,8 +4912,12 @@ impl VlConverter {
                         )
                     })
                 })
-                .await
-            }
+                .await?
+            };
+            let mut all_logs = compile_logs;
+            all_logs.extend(output.logs);
+            output.logs = all_logs;
+            Ok(output)
         } else if let Some(plugin_source) = plugin {
             self.run_on_ephemeral_worker(plugin_source, move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4497,6 +4930,7 @@ impl VlConverter {
                     )
                 })
             })
+            .await
         } else {
             self.run_on_worker(move |inner| {
                 let gf = vl_opts.google_fonts.take();
@@ -4513,59 +4947,78 @@ impl VlConverter {
         }
     }
 
-    pub async fn svg_to_png(&self, svg: &str, png_opts: PngOpts) -> Result<Vec<u8>, AnyError> {
+    pub async fn svg_to_png(&self, svg: &str, png_opts: PngOpts) -> Result<PngOutput, AnyError> {
         let scale = png_opts.scale.unwrap_or(1.0);
         let ppi = png_opts.ppi;
         let image_policy = self.image_access_policy();
         let google_fonts = self.preprocess_svg_font_requests(svg).await?;
         let svg = svg.to_string();
-        self.run_on_worker(move |inner| {
-            let inner = &mut *inner;
-            Box::pin(async move {
-                with_font_overlay!(
-                    inner,
-                    google_fonts,
-                    inner.svg_to_png_with_worker_options(&svg, scale, ppi, &image_policy)
-                )
+        let data = self
+            .run_on_worker(move |inner| {
+                let inner = &mut *inner;
+                Box::pin(async move {
+                    with_font_overlay!(
+                        inner,
+                        google_fonts,
+                        inner.svg_to_png_with_worker_options(&svg, scale, ppi, &image_policy)
+                    )
+                })
             })
+            .await?;
+        Ok(PngOutput {
+            data,
+            logs: Vec::new(),
         })
-        .await
     }
 
-    pub async fn svg_to_jpeg(&self, svg: &str, jpeg_opts: JpegOpts) -> Result<Vec<u8>, AnyError> {
+    pub async fn svg_to_jpeg(
+        &self,
+        svg: &str,
+        jpeg_opts: JpegOpts,
+    ) -> Result<JpegOutput, AnyError> {
         let scale = jpeg_opts.scale.unwrap_or(1.0);
         let quality = jpeg_opts.quality;
         let image_policy = self.image_access_policy();
         let google_fonts = self.preprocess_svg_font_requests(svg).await?;
         let svg = svg.to_string();
-        self.run_on_worker(move |inner| {
-            let inner = &mut *inner;
-            Box::pin(async move {
-                with_font_overlay!(
-                    inner,
-                    google_fonts,
-                    inner.svg_to_jpeg_with_worker_options(&svg, scale, quality, &image_policy)
-                )
+        let data = self
+            .run_on_worker(move |inner| {
+                let inner = &mut *inner;
+                Box::pin(async move {
+                    with_font_overlay!(
+                        inner,
+                        google_fonts,
+                        inner.svg_to_jpeg_with_worker_options(&svg, scale, quality, &image_policy)
+                    )
+                })
             })
+            .await?;
+        Ok(JpegOutput {
+            data,
+            logs: Vec::new(),
         })
-        .await
     }
 
-    pub async fn svg_to_pdf(&self, svg: &str, _pdf_opts: PdfOpts) -> Result<Vec<u8>, AnyError> {
+    pub async fn svg_to_pdf(&self, svg: &str, _pdf_opts: PdfOpts) -> Result<PdfOutput, AnyError> {
         let image_policy = self.image_access_policy();
         let google_fonts = self.preprocess_svg_font_requests(svg).await?;
         let svg = svg.to_string();
-        self.run_on_worker(move |inner| {
-            let inner = &mut *inner;
-            Box::pin(async move {
-                with_font_overlay!(
-                    inner,
-                    google_fonts,
-                    inner.svg_to_pdf_with_worker_options(&svg, &image_policy)
-                )
+        let data = self
+            .run_on_worker(move |inner| {
+                let inner = &mut *inner;
+                Box::pin(async move {
+                    with_font_overlay!(
+                        inner,
+                        google_fonts,
+                        inner.svg_to_pdf_with_worker_options(&svg, &image_policy)
+                    )
+                })
             })
+            .await?;
+        Ok(PdfOutput {
+            data,
+            logs: Vec::new(),
         })
-        .await
     }
 
     pub async fn get_vegaembed_bundle(&self, vl_version: VlVersion) -> Result<String, AnyError> {
@@ -4667,7 +5120,11 @@ impl VlConverter {
                 })
             });
             sender
-                .send(QueuedWork::new(work, ticket))
+                .send(QueuedWork::new(
+                    work,
+                    ticket,
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                ))
                 .await
                 .map_err(|e| anyhow!("Failed to send GetMemoryUsage to worker {idx}: {e}"))?;
             receivers.push(resp_rx);
@@ -4886,14 +5343,14 @@ fn parse_svg_with_options(
 
 pub fn vegalite_to_url(
     vl_spec: impl Into<ValueOrString>,
-    fullscreen: bool,
+    url_opts: UrlOpts,
 ) -> Result<String, AnyError> {
     let spec_str = match vl_spec.into() {
         ValueOrString::JsonString(s) => s,
         ValueOrString::Value(v) => serde_json::to_string(&v)?,
     };
     let compressed_data = lz_str::compress_to_encoded_uri_component(&spec_str);
-    let view = if fullscreen {
+    let view = if url_opts.fullscreen {
         "/view".to_string()
     } else {
         String::new()
@@ -4905,14 +5362,14 @@ pub fn vegalite_to_url(
 
 pub fn vega_to_url(
     vg_spec: impl Into<ValueOrString>,
-    fullscreen: bool,
+    url_opts: UrlOpts,
 ) -> Result<String, AnyError> {
     let spec_str = match vg_spec.into() {
         ValueOrString::JsonString(s) => s,
         ValueOrString::Value(v) => serde_json::to_string(&v)?,
     };
     let compressed_data = lz_str::compress_to_encoded_uri_component(&spec_str);
-    let view = if fullscreen {
+    let view = if url_opts.fullscreen {
         "/view".to_string()
     } else {
         String::new()
@@ -5163,7 +5620,7 @@ mod tests {
 }
         "#).unwrap();
 
-        let vg_spec = ctx
+        let vg_output = ctx
             .vegalite_to_vega(
                 vl_spec,
                 VlOpts {
@@ -5173,7 +5630,7 @@ mod tests {
             )
             .await
             .unwrap();
-        println!("vg_spec: {}", vg_spec)
+        println!("vg_spec: {}", vg_output.spec)
     }
 
     #[tokio::test]
@@ -5190,7 +5647,7 @@ mod tests {
         "#).unwrap();
 
         let ctx1 = VlConverter::new();
-        let vg_spec1 = ctx1
+        let vg_output1 = ctx1
             .vegalite_to_vega(
                 vl_spec.clone(),
                 VlOpts {
@@ -5200,10 +5657,10 @@ mod tests {
             )
             .await
             .unwrap();
-        println!("vg_spec1: {}", vg_spec1);
+        println!("vg_spec1: {}", vg_output1.spec);
 
         let ctx1 = VlConverter::new();
-        let vg_spec2 = ctx1
+        let vg_output2 = ctx1
             .vegalite_to_vega(
                 vl_spec,
                 VlOpts {
@@ -5213,7 +5670,7 @@ mod tests {
             )
             .await
             .unwrap();
-        println!("vg_spec2: {}", vg_spec2);
+        println!("vg_spec2: {}", vg_output2.spec);
     }
 
     #[tokio::test]
@@ -5576,7 +6033,7 @@ try {
 }
         "#).unwrap();
 
-        let url = vegalite_to_url(&vl_spec, false).unwrap();
+        let url = vegalite_to_url(&vl_spec, UrlOpts { fullscreen: false }).unwrap();
         let expected = concat!(
             "https://vega.github.io/editor/#/url/vega-lite/",
             "N4IgJghgLhIFygK4CcA28QAspQA4Gc4B6I5CAdwDoBzASyk0QCNF8BTZAYwHsA7KNv0o8AtkQBubahAlSIAWkg",
@@ -5677,7 +6134,7 @@ try {
         )
         .unwrap();
 
-        let url = vega_to_url(&vl_spec, true).unwrap();
+        let url = vega_to_url(&vl_spec, UrlOpts { fullscreen: true }).unwrap();
         println!("{url}");
         let expected = concat!(
             "https://vega.github.io/editor/#/url/vega/",
@@ -5997,7 +6454,7 @@ try {
         let svg = svg_with_href(
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAgMBgLP4r9kAAAAASUVORK5CYII=",
         );
-        let png = converter
+        let output = converter
             .svg_to_png(
                 &svg,
                 PngOpts {
@@ -6007,7 +6464,7 @@ try {
             )
             .await
             .unwrap();
-        assert!(png.starts_with(&[137, 80, 78, 71]));
+        assert!(output.data.starts_with(&[137, 80, 78, 71]));
     }
 
     #[tokio::test]
@@ -6042,11 +6499,11 @@ try {
         .unwrap();
         let spec = vega_spec_with_data_url("data:text/csv,a,b%0A1,2");
 
-        let svg = converter
+        let output = converter
             .vega_to_svg(spec, VgOpts::default(), SvgOpts::default())
             .await
             .unwrap();
-        assert!(svg.contains("<svg"));
+        assert!(output.svg.contains("<svg"));
     }
 
     #[tokio::test]
@@ -6212,7 +6669,7 @@ try {
         })
         .unwrap();
 
-        let pdf = converter
+        let output = converter
             .vegalite_to_pdf(
                 vegalite_spec_with_image_url(&server.url("/image.svg")),
                 VlOpts {
@@ -6223,7 +6680,7 @@ try {
             )
             .await
             .unwrap();
-        assert!(pdf.starts_with(b"%PDF"));
+        assert!(output.data.starts_with(b"%PDF"));
     }
 
     #[test]
@@ -6373,7 +6830,11 @@ try {
                 .next_sender()
                 .expect("pool should return the open sender");
             sender
-                .try_send(QueuedWork::new(make_test_work(), ticket))
+                .try_send(QueuedWork::new(
+                    make_test_work(),
+                    ticket,
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                ))
                 .expect("dispatch should use open sender, not closed sender");
             let queued = open_receiver
                 .try_recv()
@@ -6394,7 +6855,11 @@ try {
 
         let (sender, ticket) = pool.next_sender().unwrap();
         sender
-            .send(QueuedWork::new(make_test_work(), ticket))
+            .send(QueuedWork::new(
+                make_test_work(),
+                ticket,
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            ))
             .await
             .unwrap();
         assert_eq!(
@@ -6403,10 +6868,15 @@ try {
         );
 
         let (sender, ticket) = pool.next_sender().unwrap();
-        let blocked_send =
-            tokio::spawn(
-                async move { sender.send(QueuedWork::new(make_test_work(), ticket)).await },
-            );
+        let blocked_send = tokio::spawn(async move {
+            sender
+                .send(QueuedWork::new(
+                    make_test_work(),
+                    ticket,
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                ))
+                .await
+        });
         tokio::task::yield_now().await;
 
         assert_eq!(
@@ -6527,7 +6997,7 @@ try {
             }
         });
 
-        let svg = converter
+        let output = converter
             .vegalite_to_svg(
                 vl_spec,
                 VlOpts {
@@ -6538,7 +7008,7 @@ try {
             )
             .await
             .unwrap();
-        assert!(svg.trim_start().starts_with("<svg"));
+        assert!(output.svg.trim_start().starts_with("<svg"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -6576,8 +7046,8 @@ try {
         }
 
         for task in tasks {
-            let svg = task.await.unwrap().unwrap();
-            assert!(svg.trim_start().starts_with("<svg"));
+            let output = task.await.unwrap().unwrap();
+            assert!(output.svg.trim_start().starts_with("<svg"));
         }
     }
 

--- a/vl-convert-rs/src/html.rs
+++ b/vl-convert-rs/src/html.rs
@@ -1,7 +1,7 @@
 use crate::converter::{
-    classify_and_request_fonts, classify_scenegraph_fonts, FontAnalysis, GoogleFontRequest,
-    HtmlOpts, InnerVlConverter, MissingFontsPolicy, ResolvedPlugin, ValueOrString, VgOpts,
-    VlConverter, VlOpts,
+    apply_spec_overrides, classify_and_request_fonts, classify_scenegraph_fonts, FontAnalysis,
+    GoogleFontRequest, HtmlOpts, HtmlOutput, InnerVlConverter, MissingFontsPolicy, ResolvedPlugin,
+    ValueOrString, VgOpts, VlConverter, VlOpts,
 };
 use crate::deno_emit::{bundle, BundleOptions, BundleType, EmitOptions, SourceMapOption};
 use crate::extract::{
@@ -349,7 +349,7 @@ impl VlConverter {
         }
 
         let vg_spec: ValueOrString = vega_spec.into();
-        let msgpack_bytes: Vec<u8> = self
+        let sg_output = self
             .run_on_worker(move |inner: &mut InnerVlConverter| {
                 let gf = vg_opts.google_fonts.take();
                 let inner = &mut *inner;
@@ -362,7 +362,7 @@ impl VlConverter {
                 })
             })
             .await?;
-        let sg: serde_json::Value = rmp_serde::from_slice(&msgpack_bytes)?;
+        let sg: serde_json::Value = rmp_serde::from_slice(&sg_output.data)?;
         Ok(sg)
     }
 
@@ -628,12 +628,12 @@ impl VlConverter {
         include_font_face: bool,
         subset_fonts: bool,
     ) -> Result<Vec<FontInfo>, AnyError> {
-        let vega_spec = self.vegalite_to_vega(vl_spec, vl_opts.clone()).await?;
+        let vega_spec = self.vegalite_to_vega(vl_spec, vl_opts.clone()).await?.spec;
         let vg_opts = VgOpts {
             format_locale: vl_opts.format_locale,
             time_format_locale: vl_opts.time_format_locale,
             google_fonts: vl_opts.google_fonts,
-            vega_plugin: None,
+            ..Default::default()
         };
         self.vega_fonts(
             vega_spec,
@@ -726,7 +726,7 @@ impl VlConverter {
         vl_spec: impl Into<ValueOrString>,
         mut vl_opts: VlOpts,
         html_opts: HtmlOpts,
-    ) -> Result<String, AnyError> {
+    ) -> Result<HtmlOutput, AnyError> {
         let HtmlOpts { bundle, renderer } = html_opts;
         self.apply_vl_defaults(&mut vl_opts);
         let vl_version = vl_opts.vl_version;
@@ -736,17 +736,19 @@ impl VlConverter {
         let embed_local = self.inner.config.embed_local_fonts;
 
         let has_font_work = auto_install || embed_local || vl_opts.google_fonts.is_some();
+        let mut logs = Vec::new();
         let font_head_html = if has_font_work {
-            let vega_spec = self
+            let vega_output = self
                 .vegalite_to_vega(vl_spec.clone(), vl_opts.clone())
                 .await?;
+            logs = vega_output.logs;
             let vg_opts = VgOpts {
                 format_locale: vl_opts.format_locale.clone(),
                 time_format_locale: vl_opts.time_format_locale.clone(),
                 google_fonts: vl_opts.google_fonts.clone(),
-                vega_plugin: None,
+                ..Default::default()
             };
-            self.build_font_head_html(vega_spec, vg_opts, bundle, auto_install, embed_local)
+            self.build_font_head_html(vega_output.spec, vg_opts, bundle, auto_install, embed_local)
                 .await?
         } else {
             String::new()
@@ -776,14 +778,18 @@ impl VlConverter {
             Some(&resolved_plugins_owned)
         };
         let has_plugins = resolved_plugins.is_some();
+        let vl_spec =
+            apply_spec_overrides(vl_spec, &vl_opts.background, vl_opts.width, vl_opts.height)?;
         let code = get_vega_or_vegalite_script(
             vl_spec,
             vl_opts.to_embed_opts(renderer)?,
             resolved_plugins,
             bundle,
         )?;
-        self.build_html(&code, vl_version, bundle, &font_head_html, has_plugins)
-            .await
+        let html = self
+            .build_html(&code, vl_version, bundle, &font_head_html, has_plugins)
+            .await?;
+        Ok(HtmlOutput { html, logs })
     }
 
     /// Convert a Vega spec to a self-contained HTML page.
@@ -803,7 +809,7 @@ impl VlConverter {
         vg_spec: impl Into<ValueOrString>,
         mut vg_opts: VgOpts,
         html_opts: HtmlOpts,
-    ) -> Result<String, AnyError> {
+    ) -> Result<HtmlOutput, AnyError> {
         let HtmlOpts { bundle, renderer } = html_opts;
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
@@ -853,20 +859,27 @@ impl VlConverter {
             Some(&resolved_plugins_owned)
         };
         let has_plugins = resolved_plugins.is_some();
+        let vg_spec =
+            apply_spec_overrides(vg_spec, &vg_opts.background, vg_opts.width, vg_opts.height)?;
         let code = get_vega_or_vegalite_script(
             vg_spec,
             vg_opts.to_embed_opts(renderer)?,
             resolved_plugins,
             bundle,
         )?;
-        self.build_html(
-            &code,
-            Default::default(),
-            bundle,
-            &font_head_html,
-            has_plugins,
-        )
-        .await
+        let html = self
+            .build_html(
+                &code,
+                Default::default(),
+                bundle,
+                &font_head_html,
+                has_plugins,
+            )
+            .await?;
+        Ok(HtmlOutput {
+            html,
+            logs: Vec::new(),
+        })
     }
 }
 

--- a/vl-convert-rs/src/lib.rs
+++ b/vl-convert-rs/src/lib.rs
@@ -27,9 +27,10 @@ extern crate deno_core;
 
 #[allow(deprecated)]
 pub use converter::{
-    vlc_config_path, BaseUrlSetting, GoogleFontRequest, HtmlOpts, JpegOpts, PdfOpts, PngOpts,
-    Renderer, SvgOpts, VgOpts, VlConverter, VlConverterConfig, VlOpts, VlcConfig,
-    WorkerMemoryUsage,
+    vlc_config_path, BaseUrlSetting, GoogleFontRequest, HtmlOpts, HtmlOutput, JpegOpts, JpegOutput,
+    LogEntry, PdfOpts, PdfOutput, PngOpts, PngOutput, Renderer, ScenegraphMsgpackOutput,
+    ScenegraphOutput, SvgOpts, SvgOutput, VegaOutput, VgOpts, VlConverter, VlConverterConfig,
+    VlOpts, VlcConfig, WorkerMemoryUsage,
 };
 pub use deno_core::anyhow;
 pub use extract::{FontInfo, FontSource, FontVariant};

--- a/vl-convert-rs/tests/test_config.rs
+++ b/vl-convert-rs/tests/test_config.rs
@@ -27,15 +27,15 @@ async fn test_custom_theme_applied() {
     })
     .unwrap();
 
-    let svg = converter
+    let output = converter
         .vegalite_to_svg(simple_vl_bar_spec(), VlOpts::default(), SvgOpts::default())
         .await
         .unwrap();
 
     assert!(
-        svg.contains("#abcdef"),
+        output.svg.contains("#abcdef"),
         "SVG should contain the custom theme background color. Got: {}",
-        &svg[..svg.len().min(500)]
+        &output.svg[..output.svg.len().min(500)]
     );
 }
 
@@ -52,7 +52,7 @@ async fn test_per_request_theme_overrides_default() {
     .unwrap();
 
     // Per-request "dark" theme should override the default "mytest"
-    let svg = converter
+    let output = converter
         .vegalite_to_svg(
             simple_vl_bar_spec(),
             VlOpts {
@@ -66,12 +66,12 @@ async fn test_per_request_theme_overrides_default() {
 
     // Should NOT have the custom background
     assert!(
-        !svg.contains("#abcdef"),
+        !output.svg.contains("#abcdef"),
         "Per-request theme should override the default custom theme"
     );
     // Should have the dark theme's background
     assert!(
-        svg.contains("#333"),
+        output.svg.contains("#333"),
         "SVG should contain the dark theme background"
     );
 }
@@ -116,13 +116,13 @@ async fn test_default_theme_without_custom_themes() {
     })
     .unwrap();
 
-    let svg = converter
+    let output = converter
         .vegalite_to_svg(simple_vl_bar_spec(), VlOpts::default(), SvgOpts::default())
         .await
         .unwrap();
 
     assert!(
-        svg.contains("#333"),
+        output.svg.contains("#333"),
         "SVG should contain the dark theme background"
     );
 }
@@ -147,7 +147,7 @@ async fn test_default_locale_applied() {
         }
     });
 
-    let svg = converter
+    let output = converter
         .vegalite_to_svg(spec, VlOpts::default(), SvgOpts::default())
         .await
         .unwrap();
@@ -155,9 +155,9 @@ async fn test_default_locale_applied() {
     // French locale uses non-breaking space as thousands separator and comma as decimal
     // The exact rendering depends on Vega's formatting, but it should differ from "1,234.5"
     assert!(
-        !svg.contains("1,234.5"),
+        !output.svg.contains("1,234.5"),
         "With fr-FR locale, should not use English number formatting. Got: {}",
-        &svg[..svg.len().min(500)]
+        &output.svg[..output.svg.len().min(500)]
     );
 }
 
@@ -181,7 +181,7 @@ async fn test_per_request_locale_overrides_default() {
     });
 
     // Per-request en-US should override the default fr-FR
-    let svg = converter
+    let output = converter
         .vegalite_to_svg(
             spec,
             VlOpts {
@@ -196,8 +196,8 @@ async fn test_per_request_locale_overrides_default() {
         .unwrap();
 
     assert!(
-        svg.contains("1,234.5"),
+        output.svg.contains("1,234.5"),
         "Per-request en-US locale should produce English formatting. Got: {}",
-        &svg[..svg.len().min(500)]
+        &output.svg[..output.svg.len().min(500)]
     );
 }

--- a/vl-convert-rs/tests/test_plugins.rs
+++ b/vl-convert-rs/tests/test_plugins.rs
@@ -40,7 +40,7 @@ fn test_plugin_custom_scheme_png() {
     .unwrap();
 
     let vg_spec = load_vg_spec("plugin_custom_scheme");
-    let png_data = block_on(converter.vega_to_png(
+    let output = block_on(converter.vega_to_png(
         vg_spec,
         VgOpts::default(),
         PngOpts {
@@ -50,7 +50,7 @@ fn test_plugin_custom_scheme_png() {
     ))
     .unwrap();
 
-    check_vg_png("plugin_custom_scheme", png_data.as_slice());
+    check_vg_png("plugin_custom_scheme", output.data.as_slice());
 }
 
 #[tokio::test]
@@ -64,14 +64,14 @@ async fn test_plugin_registers_expression_function() {
     .unwrap();
 
     let spec = vega_spec_with_expression("double(7)");
-    let svg = converter
+    let output = converter
         .vega_to_svg(spec, VgOpts::default(), SvgOpts::default())
         .await
         .unwrap();
 
-    assert!(svg.contains("<svg"), "output should be valid SVG");
+    assert!(output.svg.contains("<svg"), "output should be valid SVG");
     assert!(
-        svg.contains("14"),
+        output.svg.contains("14"),
         "SVG should contain the result of double(7) = 14"
     );
 }
@@ -89,22 +89,22 @@ async fn test_multiple_plugins_register_different_functions() {
     .unwrap();
 
     let spec_triple = vega_spec_with_expression("triple(4)");
-    let svg_triple = converter
+    let output_triple = converter
         .vega_to_svg(spec_triple, VgOpts::default(), SvgOpts::default())
         .await
         .unwrap();
     assert!(
-        svg_triple.contains("12"),
+        output_triple.svg.contains("12"),
         "SVG should contain the result of triple(4) = 12"
     );
 
     let spec_add = vega_spec_with_expression("addTen(7)");
-    let svg_add = converter
+    let output_add = converter
         .vega_to_svg(spec_add, VgOpts::default(), SvgOpts::default())
         .await
         .unwrap();
     assert!(
-        svg_add.contains("17"),
+        output_add.svg.contains("17"),
         "SVG should contain the result of addTen(7) = 17"
     );
 }
@@ -220,7 +220,7 @@ async fn test_plugin_html_export_contains_module_script() {
         }]
     });
 
-    let html = converter
+    let output = converter
         .vega_to_html(
             spec,
             VgOpts::default(),
@@ -233,11 +233,11 @@ async fn test_plugin_html_export_contains_module_script() {
         .unwrap();
 
     assert!(
-        html.contains(r#"type="module""#),
+        output.html.contains(r#"type="module""#),
         "HTML should use <script type=\"module\"> when plugins are present"
     );
     assert!(
-        html.contains("__vlcLoadPlugin"),
+        output.html.contains("__vlcLoadPlugin"),
         "HTML should contain the __vlcLoadPlugin helper for inline plugin loading"
     );
 }
@@ -261,15 +261,15 @@ async fn test_file_path_plugin() {
     .unwrap();
 
     let spec = vega_spec_with_expression("fromFile(7)");
-    let svg = converter
+    let output = converter
         .vega_to_svg(spec, VgOpts::default(), SvgOpts::default())
         .await
         .unwrap();
 
     assert!(
-        svg.contains("107"),
+        output.svg.contains("107"),
         "SVG should contain fromFile(7) = 107, got: {}",
-        &svg[..svg.len().min(400)]
+        &output.svg[..output.svg.len().min(400)]
     );
 }
 
@@ -296,15 +296,15 @@ export default function(vega) {
     .unwrap();
 
     let spec = vega_spec_with_expression("d3scaled(0.5)");
-    let svg = converter
+    let output = converter
         .vega_to_svg(spec, VgOpts::default(), SvgOpts::default())
         .await
         .expect("URL plugin conversion must succeed (requires network)");
 
     assert!(
-        svg.contains("50"),
+        output.svg.contains("50"),
         "d3scaled(0.5) should produce 50 in SVG output. Got: {}",
-        &svg[..svg.len().min(500)]
+        &output.svg[..output.svg.len().min(500)]
     );
 }
 
@@ -329,15 +329,15 @@ export default function(vega) {
     .unwrap();
 
     let spec = vega_spec_with_expression("d3scaled10(5)");
-    let svg = converter
+    let output = converter
         .vega_to_svg(spec, VgOpts::default(), SvgOpts::default())
         .await
         .expect("Inline plugin with HTTP import must succeed (requires network)");
 
     assert!(
-        svg.contains("500"),
+        output.svg.contains("500"),
         "d3scaled10(5) should produce 500 in SVG output. Got: {}",
-        &svg[..svg.len().min(500)]
+        &output.svg[..output.svg.len().min(500)]
     );
 }
 
@@ -353,7 +353,7 @@ async fn test_per_request_plugin_works() {
     .unwrap();
 
     let spec = vega_spec_with_expression("perReq(1)");
-    let svg = converter
+    let output = converter
         .vega_to_svg(
             spec,
             VgOpts {
@@ -366,9 +366,9 @@ async fn test_per_request_plugin_works() {
         .unwrap();
 
     assert!(
-        svg.contains("100"),
+        output.svg.contains("100"),
         "SVG should contain perReq(1) = 100. Got: {}",
-        &svg[..svg.len().min(400)]
+        &output.svg[..output.svg.len().min(400)]
     );
 }
 
@@ -386,7 +386,7 @@ async fn test_per_request_plugin_isolation() {
 
     // First conversion with plugin — should succeed
     let spec = vega_spec_with_expression("ephExpr()");
-    let svg = converter
+    let output = converter
         .vega_to_svg(
             spec.clone(),
             VgOpts {
@@ -397,7 +397,7 @@ async fn test_per_request_plugin_isolation() {
         )
         .await
         .unwrap();
-    assert!(svg.contains("777"), "ephExpr() should produce 777");
+    assert!(output.svg.contains("777"), "ephExpr() should produce 777");
 
     // Second conversion WITHOUT plugin — 'ephExpr' should NOT be available
     // (true isolation: the ephemeral worker was dropped)
@@ -406,9 +406,9 @@ async fn test_per_request_plugin_isolation() {
         .await;
     // The conversion should either fail (unknown expression) or produce no "777"
     match result {
-        Ok(svg) => {
+        Ok(output) => {
             assert!(
-                !svg.contains("777"),
+                !output.svg.contains("777"),
                 "ephExpr should NOT be available on the main pool worker"
             );
         }
@@ -459,7 +459,7 @@ async fn test_per_request_plugin_with_config_level_plugins() {
 
     // Use reqFn in the spec — both config and request plugins should be active
     let spec = vega_spec_with_expression("reqFn(configFn(4))");
-    let svg = converter
+    let output = converter
         .vega_to_svg(
             spec,
             VgOpts {
@@ -473,9 +473,9 @@ async fn test_per_request_plugin_with_config_level_plugins() {
 
     // configFn(4) = 12, reqFn(12) = 62
     assert!(
-        svg.contains("62"),
+        output.svg.contains("62"),
         "SVG should contain reqFn(configFn(4)) = 62. Got: {}",
-        &svg[..svg.len().min(400)]
+        &output.svg[..output.svg.len().min(400)]
     );
 }
 
@@ -500,7 +500,7 @@ async fn test_per_request_plugin_html_export() {
         }}}]
     });
 
-    let html = converter
+    let output = converter
         .vega_to_html(
             spec,
             VgOpts {
@@ -516,11 +516,11 @@ async fn test_per_request_plugin_html_export() {
         .unwrap();
 
     assert!(
-        html.contains("htmlReq"),
+        output.html.contains("htmlReq"),
         "HTML should contain the per-request plugin source"
     );
     assert!(
-        html.contains(r#"type="module""#),
+        output.html.contains(r#"type="module""#),
         "HTML should use module script when plugins present"
     );
 }

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -366,7 +366,7 @@ mod test_vegalite_to_vega {
         let vg_result = block_on(
             converter.vegalite_to_vega(vl_spec, VlOpts{vl_version, ..Default::default()}
             )
-        ).ok();
+        ).ok().map(|output| output.spec);
 
         check_vg(name, vl_version, vg_result);
     }
@@ -408,15 +408,15 @@ mod test_vegalite_to_html_no_bundle {
         // Create Vega-Lite Converter and perform conversion
         let converter = VlConverter::new();
 
-        let html_result = block_on(
+        let output = block_on(
             converter.vegalite_to_html(vl_spec, VlOpts{vl_version, ..Default::default()}, HtmlOpts { bundle: false, renderer: Renderer::Canvas })
         ).unwrap();
 
         // Check for expected patterns
-        assert!(html_result.starts_with("<!DOCTYPE html>"));
-        assert!(html_result.contains(&format!("cdn.jsdelivr.net/npm/vega-lite@{}", vl_version.to_semver())));
-        assert!(html_result.contains("cdn.jsdelivr.net/npm/vega@6"));
-        assert!(html_result.contains("cdn.jsdelivr.net/npm/vega-embed@6"));
+        assert!(output.html.starts_with("<!DOCTYPE html>"));
+        assert!(output.html.contains(&format!("cdn.jsdelivr.net/npm/vega-lite@{}", vl_version.to_semver())));
+        assert!(output.html.contains("cdn.jsdelivr.net/npm/vega@6"));
+        assert!(output.html.contains("cdn.jsdelivr.net/npm/vega-embed@6"));
     }
 
     #[test]
@@ -456,14 +456,14 @@ mod test_vegalite_to_html_bundle {
         // Create Vega-Lite Converter and perform conversion
         let converter = VlConverter::new();
 
-        let html_result = block_on(
+        let output = block_on(
             converter.vegalite_to_html(vl_spec, VlOpts{vl_version, ..Default::default()}, HtmlOpts { bundle: true, renderer: Renderer::Svg })
         ).unwrap();
 
         // Check for expected patterns
-        assert!(html_result.starts_with("<!DOCTYPE html>"));
-        assert!(html_result.contains(vl_version.to_semver()));
-        assert!(html_result.contains("<div id=\"vega-chart\">"));
+        assert!(output.html.starts_with("<!DOCTYPE html>"));
+        assert!(output.html.contains(vl_version.to_semver()));
+        assert!(output.html.contains("<div id=\"vega-chart\">"));
     }
 
     #[test]
@@ -502,15 +502,15 @@ mod test_svg {
         let converter = VlConverter::new();
 
         // Convert to vega first
-        let vg_spec =
+        let vg_output =
             block_on(converter.vegalite_to_vega(vl_spec.clone(), VlOpts{vl_version, ..Default::default()})).unwrap();
 
-        let svg = block_on(converter.vega_to_svg(vg_spec, Default::default(), SvgOpts::default())).unwrap();
-        check_svg(name, vl_version, None, &svg);
+        let output = block_on(converter.vega_to_svg(vg_output.spec, Default::default(), SvgOpts::default())).unwrap();
+        check_svg(name, vl_version, None, &output.svg);
 
         // Convert directly to svg
-        let svg = block_on(converter.vegalite_to_svg(vl_spec, VlOpts{vl_version, ..Default::default()}, SvgOpts::default())).unwrap();
-        check_svg(name, vl_version, None, &svg);
+        let output = block_on(converter.vegalite_to_svg(vl_spec, VlOpts{vl_version, ..Default::default()}, SvgOpts::default())).unwrap();
+        check_svg(name, vl_version, None, &output.svg);
     }
 
     #[test]
@@ -542,7 +542,7 @@ mod test_svg_allowed_base_url {
         }).unwrap();
 
         // Convert to vega first
-        let vg_spec = block_on(converter.vegalite_to_vega(
+        let vg_output = block_on(converter.vegalite_to_vega(
             vl_spec.clone(),
             VlOpts {
                 vl_version,
@@ -552,16 +552,16 @@ mod test_svg_allowed_base_url {
         .unwrap();
 
         // Check with matching base URL
-        let svg = block_on(converter.vega_to_svg(
-            vg_spec.clone(),
+        let output = block_on(converter.vega_to_svg(
+            vg_output.spec.clone(),
             VgOpts::default(),
             SvgOpts::default(),
         ))
         .unwrap();
-        check_svg(name, vl_version, None, &svg);
+        check_svg(name, vl_version, None, &output.svg);
 
         // Convert directly to svg
-        let svg = block_on(converter.vegalite_to_svg(
+        let output = block_on(converter.vegalite_to_svg(
             vl_spec.clone(),
             VlOpts {
                 vl_version,
@@ -570,7 +570,7 @@ mod test_svg_allowed_base_url {
             SvgOpts::default(),
         ))
         .unwrap();
-        check_svg(name, vl_version, None, &svg);
+        check_svg(name, vl_version, None, &output.svg);
 
         // Check for error with non-matching URL
         let converter_blocked = VlConverter::with_config(VlcConfig {
@@ -579,7 +579,7 @@ mod test_svg_allowed_base_url {
         }).unwrap();
 
         let Err(result) = block_on(converter_blocked.vega_to_svg(
-            vg_spec,
+            vg_output.spec,
             VgOpts::default(),
             SvgOpts::default(),
         )) else {
@@ -631,15 +631,15 @@ mod test_scenegraph {
         let converter = VlConverter::new();
 
         // Convert to vega first
-        let vg_spec =
+        let vg_output =
             block_on(converter.vegalite_to_vega(vl_spec.clone(), VlOpts{vl_version, ..Default::default()})).unwrap();
 
-        let sg = block_on(converter.vega_to_scenegraph(vg_spec, Default::default())).unwrap();
-        check_scenegraph(name, vl_version, None, &sg);
+        let output = block_on(converter.vega_to_scenegraph(vg_output.spec, Default::default())).unwrap();
+        check_scenegraph(name, vl_version, None, &output.scenegraph);
 
-        // Convert directly to svg
-        let sg = block_on(converter.vegalite_to_scenegraph(vl_spec, VlOpts{vl_version, ..Default::default()})).unwrap();
-        check_scenegraph(name, vl_version, None, &sg);
+        // Convert directly to scenegraph
+        let output = block_on(converter.vegalite_to_scenegraph(vl_spec, VlOpts{vl_version, ..Default::default()})).unwrap();
+        check_scenegraph(name, vl_version, None, &output.scenegraph);
     }
 
     #[test]
@@ -692,18 +692,18 @@ mod test_png_no_theme {
         let converter = VlConverter::new();
 
         // Convert to vega first
-        let vg_spec = block_on(
+        let vg_output = block_on(
             converter.vegalite_to_vega(vl_spec.clone(), VlOpts{vl_version, ..Default::default()})
         ).unwrap();
 
-        let png_data = block_on(converter.vega_to_png(vg_spec, Default::default(), PngOpts { scale: Some(scale), ppi: None })).unwrap();
-        check_png_with_threshold(name, vl_version, None, png_data.as_slice(), dssim_threshold);
+        let output = block_on(converter.vega_to_png(vg_output.spec, Default::default(), PngOpts { scale: Some(scale), ppi: None })).unwrap();
+        check_png_with_threshold(name, vl_version, None, output.data.as_slice(), dssim_threshold);
 
         // Convert directly to png
-        let png_data = block_on(
+        let output = block_on(
             converter.vegalite_to_png(vl_spec, VlOpts{vl_version, ..Default::default()}, PngOpts { scale: Some(scale), ppi: None })
         ).unwrap();
-        check_png_with_threshold(name, vl_version, None, png_data.as_slice(), dssim_threshold);
+        check_png_with_threshold(name, vl_version, None, output.data.as_slice(), dssim_threshold);
     }
 
     #[test]
@@ -731,17 +731,17 @@ mod test_png_google_fonts {
             ..Default::default()
         }).unwrap();
 
-        let vg_spec = block_on(
+        let vg_output = block_on(
             converter.vegalite_to_vega(vl_spec.clone(), VlOpts{vl_version, ..Default::default()})
         ).unwrap();
 
-        let png_data = block_on(converter.vega_to_png(vg_spec, Default::default(), PngOpts { scale: Some(2.0), ppi: None })).unwrap();
-        check_png("google_fonts", vl_version, None, png_data.as_slice());
+        let output = block_on(converter.vega_to_png(vg_output.spec, Default::default(), PngOpts { scale: Some(2.0), ppi: None })).unwrap();
+        check_png("google_fonts", vl_version, None, output.data.as_slice());
 
-        let png_data = block_on(
+        let output = block_on(
             converter.vegalite_to_png(vl_spec, VlOpts{vl_version, ..Default::default()}, PngOpts { scale: Some(2.0), ppi: None })
         ).unwrap();
-        check_png("google_fonts", vl_version, None, png_data.as_slice());
+        check_png("google_fonts", vl_version, None, output.data.as_slice());
     }
 
     #[test]
@@ -778,22 +778,19 @@ mod test_png_theme_config {
         let converter = VlConverter::new();
 
         // Convert directly to png with theme and config that overrides background color
-        let png_data = block_on(
+        let output = block_on(
             converter.vegalite_to_png(
                 vl_spec.clone(),
                 VlOpts {
                     vl_version,
                     theme: Some(theme.to_string()),
                     config: Some(json!({"background": BACKGROUND_COLOR})),
-                    format_locale: None,
-                    time_format_locale: None,
-                    google_fonts: None,
-                    vega_plugin: None,
+                    ..Default::default()
                 },
                 PngOpts { scale: Some(scale), ppi: None },
             )
         ).unwrap();
-        check_png(name, vl_version, Some(theme), png_data.as_slice());
+        check_png(name, vl_version, Some(theme), output.data.as_slice());
 
         // Patch spec to put theme in `vl_spec.usermeta.embedOptions.theme` and don't pass theme
         // argument
@@ -803,22 +800,18 @@ mod test_png_theme_config {
             "embedOptions": {"theme": theme.to_string()}
         }));
 
-        let png_data = block_on(
+        let output = block_on(
             converter.vegalite_to_png(
                 usermeta_spec,
                 VlOpts {
                     vl_version,
-                    theme: None,
                     config: Some(json!({"background": BACKGROUND_COLOR})),
-                    format_locale: None,
-                    time_format_locale: None,
-                    google_fonts: None,
-                    vega_plugin: None,
+                    ..Default::default()
                 },
                 PngOpts { scale: Some(scale), ppi: None },
             )
         ).unwrap();
-        check_png(name, vl_version, Some(theme), png_data.as_slice());
+        check_png(name, vl_version, Some(theme), output.data.as_slice());
     }
 
     #[test]
@@ -836,7 +829,7 @@ async fn test_font_with_quotes() {
     // Create Vega-Lite Converter and perform conversion
     let converter = VlConverter::new();
 
-    let png_data = converter
+    let output = converter
         .vegalite_to_png(
             vl_spec,
             VlOpts {
@@ -851,7 +844,7 @@ async fn test_font_with_quotes() {
         .await
         .unwrap();
 
-    check_png(name, vl_version, None, png_data.as_slice());
+    check_png(name, vl_version, None, output.data.as_slice());
 }
 
 #[tokio::test]
@@ -871,7 +864,7 @@ async fn test_locale() {
     let converter = VlConverter::new();
 
     // Convert with locale objects
-    let png_data = converter
+    let output = converter
         .vegalite_to_png(
             vl_spec.clone(),
             VlOpts {
@@ -888,10 +881,10 @@ async fn test_locale() {
         .await
         .unwrap();
 
-    check_png(name, vl_version, None, png_data.as_slice());
+    check_png(name, vl_version, None, output.data.as_slice());
 
     // Convert with locale names
-    let png_data = converter
+    let output = converter
         .vegalite_to_png(
             vl_spec,
             VlOpts {
@@ -910,7 +903,7 @@ async fn test_locale() {
         .await
         .unwrap();
 
-    check_png(name, vl_version, None, png_data.as_slice());
+    check_png(name, vl_version, None, output.data.as_slice());
 }
 #[rustfmt::skip]
 mod test_jpeg {
@@ -943,17 +936,17 @@ mod test_jpeg {
         let converter = VlConverter::new();
 
         // Convert to vega first
-        let vg_spec =
+        let vg_output =
             block_on(converter.vegalite_to_vega(vl_spec.clone(), VlOpts{vl_version, ..Default::default()})).unwrap();
 
-        let jpeg_bytes = block_on(converter.vega_to_jpeg(vg_spec, Default::default(), JpegOpts::default())).unwrap();
+        let output = block_on(converter.vega_to_jpeg(vg_output.spec, Default::default(), JpegOpts::default())).unwrap();
 
         // Check for JPEG prefix
-        assert_eq!(&jpeg_bytes.as_slice()[..10], b"\xff\xd8\xff\xe0\x00\x10JFIF");
+        assert_eq!(&output.data.as_slice()[..10], b"\xff\xd8\xff\xe0\x00\x10JFIF");
 
         // Convert directly to JPEG
-        let jpeg_bytes = block_on(converter.vegalite_to_jpeg(vl_spec, VlOpts{vl_version, ..Default::default()}, JpegOpts::default())).unwrap();
-        assert_eq!(&jpeg_bytes.as_slice()[..10], b"\xff\xd8\xff\xe0\x00\x10JFIF");
+        let output = block_on(converter.vegalite_to_jpeg(vl_spec, VlOpts{vl_version, ..Default::default()}, JpegOpts::default())).unwrap();
+        assert_eq!(&output.data.as_slice()[..10], b"\xff\xd8\xff\xe0\x00\x10JFIF");
     }
 
     #[test]
@@ -977,11 +970,11 @@ mod test_vega_label_transform {
         let vg_spec = load_vg_spec(name);
         let converter = VlConverter::new();
 
-        let png_data = block_on(
+        let output = block_on(
             converter.vega_to_png(vg_spec, Default::default(), PngOpts { scale: Some(scale), ppi: None })
         ).unwrap();
 
-        check_vg_png(name, png_data.as_slice());
+        check_vg_png(name, output.data.as_slice());
     }
 
     #[test]
@@ -995,7 +988,7 @@ async fn check_svg_to_png_baseline(name: &str, svg: &str) {
     })
     .unwrap();
 
-    let png_data = converter
+    let output = converter
         .svg_to_png(
             svg,
             PngOpts {
@@ -1015,20 +1008,20 @@ async fn check_svg_to_png_baseline(name: &str, svg: &str) {
 
     if expected_path.exists() {
         let expected_dssim = dssim::load_image(&Dssim::new(), &expected_path).unwrap();
-        let actual_dssim = to_dssim(png_data.as_slice()).unwrap();
+        let actual_dssim = to_dssim(output.data.as_slice()).unwrap();
         let (diff, _) = Dssim::new().compare(&expected_dssim, actual_dssim);
         if diff > 0.00011 {
             let failed_dir = root_path.join("tests").join("svg-specs").join("failed");
             fs::create_dir_all(&failed_dir).unwrap();
             let failed_path = failed_dir.join(format!("{name}.png"));
-            fs::write(&failed_path, &png_data).unwrap();
+            fs::write(&failed_path, &output.data).unwrap();
             panic!("DSSIM diff {diff} for {name}.png. Failed image written to {failed_path:?}");
         }
     } else {
         let failed_dir = root_path.join("tests").join("svg-specs").join("failed");
         fs::create_dir_all(&failed_dir).unwrap();
         let failed_path = failed_dir.join(format!("{name}.png"));
-        fs::write(&failed_path, &png_data).unwrap();
+        fs::write(&failed_path, &output.data).unwrap();
         panic!(
             "Baseline image does not exist for {name}.png. Failed image written to {failed_path:?}"
         );

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 use vl_convert_google_fonts::{FontStyle, VariantRequest};
 use vl_convert_rs::converter::{
     vega_to_url, vegalite_to_url, BaseUrlSetting, FormatLocale, GoogleFontRequest, HtmlOpts,
-    JpegOpts, MissingFontsPolicy, PdfOpts, PngOpts, Renderer, SvgOpts, TimeFormatLocale, VgOpts,
-    VlConverter, VlOpts, VlcConfig,
+    JpegOpts, MissingFontsPolicy, PdfOpts, PngOpts, Renderer, SvgOpts, TimeFormatLocale, UrlOpts,
+    VgOpts, VlConverter, VlOpts, VlcConfig,
 };
 use vl_convert_rs::module_loader::import_map::VlVersion;
 use vl_convert_rs::text::register_font_directory;
@@ -756,10 +756,30 @@ async fn main() -> Result<(), anyhow::Error> {
     if google_fonts.is_some() {
         base_config.google_fonts = google_fonts;
     }
-    base_config.num_workers = 1;
-
     let command = cli.command;
 
+    base_config.num_workers = 1;
+
+    // Wrap all conversion work in select! so Ctrl+C drops the conversion
+    // future, triggering CallerGoneGuard to terminate V8 promptly.
+    tokio::select! {
+        result = run_command(command, base_config, google_font_families) => result?,
+        _ = tokio::signal::ctrl_c() => {
+            // Returning here drops the run_command future, which drops
+            // resp_rx.await inside run_on_worker, firing CallerGoneGuard
+            // to terminate any in-flight V8 execution.
+            bail!("interrupted");
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_command(
+    command: Commands,
+    base_config: VlcConfig,
+    google_font_families: Vec<String>,
+) -> Result<(), anyhow::Error> {
     use crate::Commands::*;
     match command {
         Vl2vg {
@@ -891,7 +911,7 @@ async fn main() -> Result<(), anyhow::Error> {
         } => {
             let vl_str = read_input_string(input.as_deref())?;
             let vl_spec = serde_json::from_str(&vl_str)?;
-            let url = vegalite_to_url(&vl_spec, fullscreen)?;
+            let url = vegalite_to_url(&vl_spec, UrlOpts { fullscreen })?;
             write_output_string(output.as_deref(), &url)?
         }
         Vl2html {
@@ -916,18 +936,17 @@ async fn main() -> Result<(), anyhow::Error> {
             let renderer = renderer.unwrap_or_else(|| "svg".to_string());
 
             let converter = VlConverter::with_config(base_config)?;
-            let html = converter
+            let html_output = converter
                 .vegalite_to_html(
                     vl_spec,
                     VlOpts {
                         config,
                         theme,
                         vl_version,
-
                         format_locale,
                         time_format_locale,
                         google_fonts,
-                        vega_plugin: None,
+                        ..Default::default()
                     },
                     HtmlOpts {
                         bundle,
@@ -935,7 +954,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     },
                 )
                 .await?;
-            write_output_string(output.as_deref(), &html)?;
+            write_output_string(output.as_deref(), &html_output.html)?;
         }
         Vl2fonts {
             input,
@@ -968,11 +987,10 @@ async fn main() -> Result<(), anyhow::Error> {
                         config,
                         theme,
                         vl_version,
-
                         format_locale,
                         time_format_locale,
                         google_fonts,
-                        vega_plugin: None,
+                        ..Default::default()
                     },
                     auto_google_fonts,
                     embed_local_fonts,
@@ -1073,7 +1091,7 @@ async fn main() -> Result<(), anyhow::Error> {
         } => {
             let vg_str = read_input_string(input.as_deref())?;
             let vg_spec = serde_json::from_str(&vg_str)?;
-            let url = vega_to_url(&vg_spec, fullscreen)?;
+            let url = vega_to_url(&vg_spec, UrlOpts { fullscreen })?;
             write_output_string(output.as_deref(), &url)?
         }
         Vg2html {
@@ -1095,14 +1113,14 @@ async fn main() -> Result<(), anyhow::Error> {
             let renderer = renderer.unwrap_or_else(|| "svg".to_string());
 
             let converter = VlConverter::with_config(base_config)?;
-            let html = converter
+            let html_output = converter
                 .vega_to_html(
                     vg_spec,
                     VgOpts {
                         format_locale,
                         time_format_locale,
                         google_fonts,
-                        vega_plugin: None,
+                        ..Default::default()
                     },
                     HtmlOpts {
                         bundle,
@@ -1110,7 +1128,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     },
                 )
                 .await?;
-            write_output_string(output.as_deref(), &html)?;
+            write_output_string(output.as_deref(), &html_output.html)?;
         }
         Vg2fonts {
             input,
@@ -1163,7 +1181,7 @@ async fn main() -> Result<(), anyhow::Error> {
             register_font_dir(font_dir)?;
             let svg = read_input_string(input.as_deref())?;
             let converter = VlConverter::with_config(base_config)?;
-            let png_data = converter
+            let png_output = converter
                 .svg_to_png(
                     &svg,
                     PngOpts {
@@ -1172,7 +1190,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     },
                 )
                 .await?;
-            write_output_binary(output.as_deref(), &png_data, "PNG")?;
+            write_output_binary(output.as_deref(), &png_output.data, "PNG")?;
         }
         Svg2jpeg {
             input,
@@ -1184,7 +1202,7 @@ async fn main() -> Result<(), anyhow::Error> {
             register_font_dir(font_dir)?;
             let svg = read_input_string(input.as_deref())?;
             let converter = VlConverter::with_config(base_config)?;
-            let jpeg_data = converter
+            let jpeg_output = converter
                 .svg_to_jpeg(
                     &svg,
                     JpegOpts {
@@ -1193,7 +1211,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     },
                 )
                 .await?;
-            write_output_binary(output.as_deref(), &jpeg_data, "JPEG")?;
+            write_output_binary(output.as_deref(), &jpeg_output.data, "JPEG")?;
         }
         Svg2pdf {
             input,
@@ -1203,8 +1221,8 @@ async fn main() -> Result<(), anyhow::Error> {
             register_font_dir(font_dir)?;
             let svg = read_input_string(input.as_deref())?;
             let converter = VlConverter::with_config(base_config)?;
-            let pdf_data = converter.svg_to_pdf(&svg, PdfOpts::default()).await?;
-            write_output_binary(output.as_deref(), &pdf_data, "PDF")?;
+            let pdf_output = converter.svg_to_pdf(&svg, PdfOpts::default()).await?;
+            write_output_binary(output.as_deref(), &pdf_output.data, "PDF")?;
         }
         LsThemes => list_themes(base_config).await?,
         CatTheme { theme } => cat_theme(&theme, base_config).await?,
@@ -1584,30 +1602,27 @@ async fn vl_2_vg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let vega_json = match converter
+    let vega_output = match converter
         .vegalite_to_vega(
             vegalite_json,
             VlOpts {
                 vl_version,
                 theme,
                 config,
-                format_locale: None,
-                time_format_locale: None,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
         )
         .await
     {
-        Ok(vega_str) => vega_str,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to Vega conversion failed: {}", err);
         }
     };
     let vega_str_res = if pretty {
-        serde_json::to_string_pretty(&vega_json)
+        serde_json::to_string_pretty(&vega_output.spec)
     } else {
-        serde_json::to_string(&vega_json)
+        serde_json::to_string(&vega_output.spec)
     };
     match vega_str_res {
         Ok(vega_str) => {
@@ -1637,26 +1652,25 @@ async fn vg_2_svg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let svg = match converter
+    let svg_output = match converter
         .vega_to_svg(
             vg_spec,
             VgOpts {
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             svg_opts,
         )
         .await
     {
-        Ok(svg) => svg,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega to SVG conversion failed: {}", err);
         }
     };
 
-    write_output_string(output, &svg)?;
+    write_output_string(output, &svg_output.svg)?;
 
     Ok(())
 }
@@ -1679,14 +1693,13 @@ async fn vg_2_png(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let png_data = match converter
+    let png_output = match converter
         .vega_to_png(
             vg_spec,
             VgOpts {
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             PngOpts {
                 scale: Some(scale),
@@ -1695,13 +1708,13 @@ async fn vg_2_png(
         )
         .await
     {
-        Ok(png_data) => png_data,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega to PNG conversion failed: {}", err);
         }
     };
 
-    write_output_binary(output, &png_data, "PNG")?;
+    write_output_binary(output, &png_output.data, "PNG")?;
 
     Ok(())
 }
@@ -1724,14 +1737,13 @@ async fn vg_2_jpeg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let jpeg_data = match converter
+    let jpeg_output = match converter
         .vega_to_jpeg(
             vg_spec,
             VgOpts {
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             JpegOpts {
                 scale: Some(scale),
@@ -1740,13 +1752,13 @@ async fn vg_2_jpeg(
         )
         .await
     {
-        Ok(jpeg_data) => jpeg_data,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega to JPEG conversion failed: {}", err);
         }
     };
 
-    write_output_binary(output, &jpeg_data, "JPEG")?;
+    write_output_binary(output, &jpeg_output.data, "JPEG")?;
 
     Ok(())
 }
@@ -1766,26 +1778,25 @@ async fn vg_2_pdf(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let pdf_data = match converter
+    let pdf_output = match converter
         .vega_to_pdf(
             vg_spec,
             VgOpts {
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             PdfOpts::default(),
         )
         .await
     {
-        Ok(pdf_data) => pdf_data,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega to PDF conversion failed: {}", err);
         }
     };
 
-    write_output_binary(output, &pdf_data, "PDF")?;
+    write_output_binary(output, &pdf_output.data, "PDF")?;
 
     Ok(())
 }
@@ -1812,7 +1823,7 @@ async fn vl_2_svg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let svg = match converter
+    let svg_output = match converter
         .vegalite_to_svg(
             vl_spec,
             VlOpts {
@@ -1821,20 +1832,19 @@ async fn vl_2_svg(
                 theme,
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             svg_opts,
         )
         .await
     {
-        Ok(svg) => svg,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to SVG conversion failed: {}", err);
         }
     };
 
-    write_output_string(output, &svg)?;
+    write_output_string(output, &svg_output.svg)?;
 
     Ok(())
 }
@@ -1862,7 +1872,7 @@ async fn vl_2_png(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let png_data = match converter
+    let png_output = match converter
         .vegalite_to_png(
             vl_spec,
             VlOpts {
@@ -1871,8 +1881,7 @@ async fn vl_2_png(
                 theme,
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             PngOpts {
                 scale: Some(scale),
@@ -1881,13 +1890,13 @@ async fn vl_2_png(
         )
         .await
     {
-        Ok(png_data) => png_data,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to PNG conversion failed: {}", err);
         }
     };
 
-    write_output_binary(output, &png_data, "PNG")?;
+    write_output_binary(output, &png_output.data, "PNG")?;
 
     Ok(())
 }
@@ -1915,7 +1924,7 @@ async fn vl_2_jpeg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let jpeg_data = match converter
+    let jpeg_output = match converter
         .vegalite_to_jpeg(
             vl_spec,
             VlOpts {
@@ -1924,8 +1933,7 @@ async fn vl_2_jpeg(
                 theme,
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             JpegOpts {
                 scale: Some(scale),
@@ -1934,13 +1942,13 @@ async fn vl_2_jpeg(
         )
         .await
     {
-        Ok(jpeg_data) => jpeg_data,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to JPEG conversion failed: {}", err);
         }
     };
 
-    write_output_binary(output, &jpeg_data, "JPEG")?;
+    write_output_binary(output, &jpeg_output.data, "JPEG")?;
 
     Ok(())
 }
@@ -1966,7 +1974,7 @@ async fn vl_2_pdf(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let pdf_data = match converter
+    let pdf_output = match converter
         .vegalite_to_pdf(
             vl_spec,
             VlOpts {
@@ -1975,20 +1983,19 @@ async fn vl_2_pdf(
                 theme,
                 format_locale,
                 time_format_locale,
-                google_fonts: None,
-                vega_plugin: None,
+                ..Default::default()
             },
             PdfOpts::default(),
         )
         .await
     {
-        Ok(pdf_data) => pdf_data,
+        Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to PDF conversion failed: {}", err);
         }
     };
 
-    write_output_binary(output, &pdf_data, "PDF")?;
+    write_output_binary(output, &pdf_output.data, "PDF")?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR pull out some of the changes from initial version of https://github.com/vega/vl-convert/pull/269.

## Summary

- All 18 public conversion methods on `VlConverter` now return typed output structs (`SvgOutput`, `PngOutput`, `VegaOutput`, etc.) pairing the conversion result with `Vec<LogEntry>` captured during JS evaluation
- `LogEntry` captures all 4 Vega log levels (Error, Warn, Info, Debug) from both Vega-Lite compilation and Vega runtime expression evaluation
- Add `CallerGoneGuard` drop guard for request cancellation — allows upstream callers to cancel in-flight V8 conversions when the request is abandoned
- Add `UrlOpts` struct for URL generation, replacing bare `fullscreen: bool` parameter
- Add `width`, `height`, `background` overrides to `VgOpts`/`VlOpts` and `config` passthrough to `VgOpts`

## Motivation

The conversion methods previously returned raw values (`String`, `Vec<u8>`, `serde_json::Value`) with no way to access diagnostic messages from the Vega/Vega-Lite JS runtime. Warnings like "Infinite extent for field..." or "Log scale domain includes zero" were emitted to the Rust `log` crate but invisible to programmatic callers.

Typed output structs solve this by bundling logs with results. This enables:
- Python users to access warnings via `logging.getLogger("vl_convert_rs")` (through `pyo3_log`)
- Returning warnings in HTTP response headers (server, follow-on PR)
- Per-request log isolation under concurrent multi-worker load

The `CallerGoneGuard` enables a server to cancel expensive V8 conversions when an HTTP client disconnects or times out, rather than wasting worker capacity on abandoned requests.

## Changes

### `vl-convert-rs` (core library)

**Typed output structs** (`converter.rs`):
- `VegaOutput { spec, logs }`, `SvgOutput { svg, logs }`, `PngOutput { data, logs }`, `JpegOutput { data, logs }`, `PdfOutput { data, logs }`, `HtmlOutput { html, logs }`, `ScenegraphOutput { scenegraph, logs }`, `ScenegraphMsgpackOutput { data, logs }`
- `LogEntry { level: LogLevel, message: String }` with `LogLevel::{Error, Warn, Info, Debug}`
- Inner `InnerVlConverter` methods return typed outputs directly — each calls `std::mem::take(&mut self.last_log_entries)` to include logs

**Log capture** (`converter.rs`):
- JS `LogCollector` captures all 4 Vega log levels into an ordered `_logEntries` array with consecutive-duplicate collapsing (`(Nx)` prefix)
- `emit_js_log_messages()` reads back the JSON and pushes entries into `last_log_entries`
- Logs emitted to both Rust `log` crate (for CLI/debugging) and structured `Vec<LogEntry>` (for programmatic access)

**Request cancellation** (`converter.rs`):
- `CallerGoneGuard` — drop guard that sets `caller_gone: AtomicBool` when the caller's future is dropped
- Worker loop skips queued work if caller already disconnected
- Conversion timer thread polls `caller_gone` every 50ms and terminates V8 if set

**New options**:
- `UrlOpts { fullscreen }` replaces bare `bool` for `vegalite_to_url` / `vega_to_url`
- `VgOpts` gains `config`, `background`, `width`, `height` fields
- `VlOpts` gains `background`, `width`, `height` fields
- `apply_spec_overrides()` applies background/width/height to spec JSON before compilation or rendering
- `VlcConfig` gains `allow_google_fonts: bool`

**Other** (`html.rs`, `converter.rs`):
- Font preprocessing path preserves VL compiler logs through to final output
- `emit_js_log_messages()` clears stale entries at start to prevent log leakage on error paths

### Consumer updates

**Python bindings** (`vl-convert-python/src/lib.rs`):
- All conversion functions unwrap typed outputs (`.svg`, `.data`, `.spec`, `.html`)
- Typed `Vec<LogEntry>` not directly exposed; logs are accessible via Python's `logging` module through `pyo3_log`

**CLI** (`vl-convert/src/main.rs`):
- Unwraps typed outputs and uses `UrlOpts`
- Ctrl+C cancellation via `tokio::select!` — SIGINT drops the conversion future cleanly

**Tests** (`test_specs.rs`, `test_config.rs`, `test_plugins.rs`):
- Adapted to typed output field access
