### PR TITLE
Add CLI parity commands and server diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10436,6 +10436,7 @@ dependencies = [
  "jsonc-parser 0.32.1",
  "log",
  "predicates",
+ "rmp-serde",
  "rstest",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -27,17 +27,28 @@ Commands:
   vl2pdf     Convert a Vega-Lite specification to a PDF image
   vl2url     Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
   vl2html    Convert a Vega-Lite specification to an HTML file
+  vl2fonts   Return font metadata for a rendered Vega-Lite specification
+  vl2scenegraph
+             Convert a Vega-Lite specification to a Vega scenegraph
   vg2svg     Convert a Vega specification to an SVG image
   vg2png     Convert a Vega specification to an PNG image
   vg2jpeg    Convert a Vega specification to an JPEG image
   vg2pdf     Convert a Vega specification to an PDF image
   vg2url     Convert a Vega specification to a URL that opens the chart in the Vega editor
   vg2html    Convert a Vega specification to an HTML file
+  vg2fonts   Return font metadata for a rendered Vega specification
+  vg2scenegraph
+             Convert a Vega specification to a Vega scenegraph
+  javascript-bundle
+             Produce the JavaScript bundle used by Vega Embed integrations
   svg2png    Convert an SVG image to a PNG image
   svg2jpeg   Convert an SVG image to a JPEG image
   svg2pdf    Convert an SVG image to a PDF image
   ls-themes  List available themes
   cat-theme  Print the config JSON for a theme
+  config-path
+             Print the default vlc-config file path
+  serve      Run the HTTP conversion server
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -126,5 +137,4 @@ A directory containing additional font files can registered with the VlConvert P
 
 ### Built-in Datasets
 The [Vega Editor](https://vega.github.io/editor/) supports referring to built-in datasets as if the exist under a `data/` directory (e.g. `data/cars.json`). This is not currently supporte by VlConvert. Instead an absolute URL must be used (e.g. `https://raw.githubusercontent.com/vega/vega-datasets/next/data/cars.json`).
-
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Commands:
   vg2html    Convert a Vega specification to an HTML file
   vg2fonts   Return font metadata for a rendered Vega specification
   vg2sg      Convert a Vega specification to a Vega scenegraph
-  javascript-bundle
+  bundle-js
              Produce the JavaScript bundle used by Vega Embed integrations
   svg2png    Convert an SVG image to a PNG image
   svg2jpeg   Convert an SVG image to a JPEG image

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Commands:
   vl2url     Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
   vl2html    Convert a Vega-Lite specification to an HTML file
   vl2fonts   Return font metadata for a rendered Vega-Lite specification
-  vl2scenegraph
-             Convert a Vega-Lite specification to a Vega scenegraph
+  vl2sg      Convert a Vega-Lite specification to a Vega scenegraph
   vg2svg     Convert a Vega specification to an SVG image
   vg2png     Convert a Vega specification to an PNG image
   vg2jpeg    Convert a Vega specification to an JPEG image
@@ -37,8 +36,7 @@ Commands:
   vg2url     Convert a Vega specification to a URL that opens the chart in the Vega editor
   vg2html    Convert a Vega specification to an HTML file
   vg2fonts   Return font metadata for a rendered Vega specification
-  vg2scenegraph
-             Convert a Vega specification to a Vega scenegraph
+  vg2sg      Convert a Vega specification to a Vega scenegraph
   javascript-bundle
              Produce the JavaScript bundle used by Vega Embed integrations
   svg2png    Convert an SVG image to a PNG image
@@ -137,4 +135,3 @@ A directory containing additional font files can registered with the VlConvert P
 
 ### Built-in Datasets
 The [Vega Editor](https://vega.github.io/editor/) supports referring to built-in datasets as if the exist under a `data/` directory (e.g. `data/cars.json`). This is not currently supporte by VlConvert. Instead an absolute URL must be used (e.g. `https://raw.githubusercontent.com/vega/vega-datasets/next/data/cars.json`).
-

--- a/vl-convert-server/README.md
+++ b/vl-convert-server/README.md
@@ -142,7 +142,7 @@ Related `vl-convert serve` controls that affect conversion behavior include:
 | --- | --- |
 | `/healthz` | Liveness endpoint returning `{"status":"ok"}`. |
 | `/readyz` | Readiness endpoint. Returns 503 during admin reconfiguration or when a worker health probe fails. |
-| `/infoz` | Version metadata, supported Vega-Lite versions, and the resolved Google Fonts cache directory. |
+| `/infoz` | Version metadata, supported Vega-Lite versions, local timezone, and the resolved Google Fonts cache directory. |
 
 ## Admin API
 
@@ -156,6 +156,7 @@ Admin routes include:
 - `GET` / `POST` / `PUT /admin/config/fonts/directories` for process font
   directory state.
 - `GET` / `PUT /admin/config/fonts/cache_size` for the Google Fonts cache cap.
+- `GET /admin/diagnostics/workers` for per-worker V8 heap statistics.
 - `/admin/docs` and `/admin/api-doc/openapi.json` for the admin OpenAPI
   surface.
 

--- a/vl-convert-server/src/admin.rs
+++ b/vl-convert-server/src/admin.rs
@@ -4,6 +4,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use axum::Router;
+use serde::Serialize;
 use serde_json::json;
 use std::sync::Arc;
 use utoipa::OpenApi;
@@ -71,6 +72,7 @@ fn admin_openapi_router() -> OpenApiRouter<Arc<AdminState>> {
     OpenApiRouter::with_openapi(AdminApiDoc::openapi())
         .routes(routes!(get_budget))
         .routes(routes!(update_budget))
+        .routes(routes!(get_worker_diagnostics))
         .routes(routes!(get_config))
         .routes(routes!(patch_config))
         .routes(routes!(put_config))
@@ -122,6 +124,21 @@ struct BudgetUpdate {
     per_ip_budget_ms: Option<i64>,
     global_budget_ms: Option<i64>,
     hold_ms: Option<i64>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+struct WorkerMemoryUsageView {
+    worker_index: usize,
+    used_heap_size: usize,
+    total_heap_size: usize,
+    heap_size_limit: usize,
+    external_memory: usize,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+struct WorkerDiagnosticsView {
+    generation: u64,
+    workers: Vec<WorkerMemoryUsageView>,
 }
 
 #[utoipa::path(
@@ -177,6 +194,47 @@ async fn update_budget(
         tracker.update_estimate(est);
     }
     Json(tracker.status()).into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/diagnostics/workers",
+    responses(
+        (status = 200, description = "Worker memory usage"),
+        (status = 503, description = "Worker diagnostics unavailable"),
+    ),
+    tag = "Admin",
+)]
+async fn get_worker_diagnostics(State(admin): State<Arc<AdminState>>) -> Response {
+    let snap = admin.runtime.load_full();
+    let generation = snap.generation;
+    match snap.converter.get_worker_memory_usage().await {
+        Ok(workers) => {
+            let workers = workers
+                .into_iter()
+                .map(|worker| WorkerMemoryUsageView {
+                    worker_index: worker.worker_index,
+                    used_heap_size: worker.used_heap_size,
+                    total_heap_size: worker.total_heap_size,
+                    heap_size_limit: worker.heap_size_limit,
+                    external_memory: worker.external_memory,
+                })
+                .collect();
+            (
+                StatusCode::OK,
+                Json(WorkerDiagnosticsView {
+                    generation,
+                    workers,
+                }),
+            )
+                .into_response()
+        }
+        Err(err) => simple_error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!("worker diagnostics unavailable: {err}"),
+            admin.opaque_errors,
+        ),
+    }
 }
 
 // =============================================================================

--- a/vl-convert-server/src/config.rs
+++ b/vl-convert-server/src/config.rs
@@ -179,6 +179,7 @@ pub(crate) struct AppState {
     pub opaque_errors: bool,
     pub require_user_agent: bool,
     pub readiness: Arc<health::ReadinessState>,
+    pub local_tz: Option<String>,
     /// Shared with the gate middleware (main router) and admin handlers so
     /// every drain-participating actor works against the same coordinator.
     pub coordinator: Arc<ReconfigCoordinator>,

--- a/vl-convert-server/src/health.rs
+++ b/vl-convert-server/src/health.rs
@@ -106,7 +106,7 @@ pub async fn readyz(State(state): State<Arc<AppState>>) -> Response {
     ),
     tag = "Health"
 )]
-pub async fn infoz() -> Json<Value> {
+pub async fn infoz(State(state): State<Arc<AppState>>) -> Json<Value> {
     Json(json!({
         "version": env!("CARGO_PKG_VERSION"),
         "vega_version": import_map::VEGA_VERSION,
@@ -115,5 +115,6 @@ pub async fn infoz() -> Json<Value> {
         "vegalite_versions": crate::util::vegalite_versions(),
         "google_fonts_cache_dir": vl_convert_rs::google_fonts_cache_dir()
             .map(|p| p.to_string_lossy().into_owned()),
+        "local_tz": state.local_tz.clone(),
     }))
 }

--- a/vl-convert-server/src/lib.rs
+++ b/vl-convert-server/src/lib.rs
@@ -154,6 +154,13 @@ pub async fn build_app(
     log::info!("Initializing converter with {num_workers} worker(s)...");
     let converter = vl_convert_rs::converter::VlConverter::with_config(config)?;
     converter.warm_up()?;
+    let local_tz = match converter.get_local_tz().await {
+        Ok(tz) => tz,
+        Err(err) => {
+            log::warn!("Failed to determine local timezone for /infoz: {err}");
+            None
+        }
+    };
     log::info!("Workers initialized");
 
     // Seed the admin baseline and initial runtime snapshot from the normalized
@@ -180,6 +187,7 @@ pub async fn build_app(
         opaque_errors: serve_config.opaque_errors,
         require_user_agent: serve_config.require_user_agent,
         readiness: readiness.clone(),
+        local_tz,
         coordinator: coordinator.clone(),
     });
 

--- a/vl-convert-server/src/middleware.rs
+++ b/vl-convert-server/src/middleware.rs
@@ -496,6 +496,7 @@ mod tests {
             opaque_errors,
             require_user_agent: false,
             readiness: Arc::new(crate::health::ReadinessState::default()),
+            local_tz: None,
             coordinator: coord,
         });
 

--- a/vl-convert-server/tests/test_admin_config.rs
+++ b/vl-convert-server/tests/test_admin_config.rs
@@ -471,6 +471,31 @@ async fn test_admin_config_generation_not_exposed_on_infoz() {
     // Existing infoz surface must still include the established keys.
     assert!(body.get("version").is_some());
     assert!(body.get("vegalite_versions").is_some());
+    assert!(body.get("local_tz").is_some());
+}
+
+#[tokio::test]
+async fn test_admin_worker_diagnostics() {
+    let server = default_admin_server();
+    let resp = server
+        .handle
+        .client
+        .get(format!(
+            "{}/admin/diagnostics/workers",
+            server.admin_base_url
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["generation"], 0);
+    let workers = body["workers"]
+        .as_array()
+        .expect("workers must be an array");
+    assert!(!workers.is_empty(), "expected at least one worker");
+    assert!(workers[0]["worker_index"].is_number());
+    assert!(workers[0]["used_heap_size"].is_number());
 }
 
 fn dirs_from_get(value: &Value) -> Vec<String> {

--- a/vl-convert-server/tests/test_health.rs
+++ b/vl-convert-server/tests/test_health.rs
@@ -44,7 +44,8 @@ async fn test_health_endpoints() {
 
 /// Locks the public `/infoz` surface: the exact set of keys must be
 /// `{version, vega_version, vega_themes_version, vega_embed_version,
-/// vegalite_versions}`. Anything else (notably `generation`) would
+/// vegalite_versions, google_fonts_cache_dir, local_tz}`. Anything else
+/// (notably `generation`) would
 /// leak admin-scope observability to unauthenticated callers. Design §2.8.
 #[tokio::test]
 async fn test_infoz_surface_unchanged() {
@@ -66,6 +67,7 @@ async fn test_infoz_surface_unchanged() {
         "vega_embed_version",
         "vegalite_versions",
         "google_fonts_cache_dir",
+        "local_tz",
     ]
     .into_iter()
     .collect();

--- a/vl-convert-server/tests/test_openapi.rs
+++ b/vl-convert-server/tests/test_openapi.rs
@@ -86,6 +86,7 @@ async fn test_admin_openapi_includes_admin_paths() {
         "/admin/budget",
         "/admin/config",
         "/admin/config/fonts/directories",
+        "/admin/diagnostics/workers",
     ];
     for path in expected {
         assert!(

--- a/vl-convert/Cargo.toml
+++ b/vl-convert/Cargo.toml
@@ -30,6 +30,7 @@ predicates = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
 dssim = { workspace = true }
+rmp-serde = "1.3.0"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["client", "tokio"] }
 http-body-util = "0.1"

--- a/vl-convert/README.md
+++ b/vl-convert/README.md
@@ -24,17 +24,28 @@ Commands:
   vl2pdf     Convert a Vega-Lite specification to a PDF image
   vl2url     Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
   vl2html    Convert a Vega-Lite specification to an HTML file
+  vl2fonts   Return font metadata for a rendered Vega-Lite specification
+  vl2scenegraph
+             Convert a Vega-Lite specification to a Vega scenegraph
   vg2svg     Convert a Vega specification to an SVG image
   vg2png     Convert a Vega specification to an PNG image
   vg2jpeg    Convert a Vega specification to an JPEG image
   vg2pdf     Convert a Vega specification to an PDF image
   vg2url     Convert a Vega specification to a URL that opens the chart in the Vega editor
   vg2html    Convert a Vega specification to an HTML file
+  vg2fonts   Return font metadata for a rendered Vega specification
+  vg2scenegraph
+             Convert a Vega specification to a Vega scenegraph
+  javascript-bundle
+             Produce the JavaScript bundle used by Vega Embed integrations
   svg2png    Convert an SVG image to a PNG image
   svg2jpeg   Convert an SVG image to a JPEG image
   svg2pdf    Convert an SVG image to a PDF image
   ls-themes  List available themes
   cat-theme  Print the config JSON for a theme
+  config-path
+             Print the default vlc-config file path
+  serve      Run the HTTP conversion server
   help       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/vl-convert/README.md
+++ b/vl-convert/README.md
@@ -34,7 +34,7 @@ Commands:
   vg2html    Convert a Vega specification to an HTML file
   vg2fonts   Return font metadata for a rendered Vega specification
   vg2sg      Convert a Vega specification to a Vega scenegraph
-  javascript-bundle
+  bundle-js
              Produce the JavaScript bundle used by Vega Embed integrations
   svg2png    Convert an SVG image to a PNG image
   svg2jpeg   Convert an SVG image to a JPEG image

--- a/vl-convert/README.md
+++ b/vl-convert/README.md
@@ -25,8 +25,7 @@ Commands:
   vl2url     Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
   vl2html    Convert a Vega-Lite specification to an HTML file
   vl2fonts   Return font metadata for a rendered Vega-Lite specification
-  vl2scenegraph
-             Convert a Vega-Lite specification to a Vega scenegraph
+  vl2sg      Convert a Vega-Lite specification to a Vega scenegraph
   vg2svg     Convert a Vega specification to an SVG image
   vg2png     Convert a Vega specification to an PNG image
   vg2jpeg    Convert a Vega specification to an JPEG image
@@ -34,8 +33,7 @@ Commands:
   vg2url     Convert a Vega specification to a URL that opens the chart in the Vega editor
   vg2html    Convert a Vega specification to an HTML file
   vg2fonts   Return font metadata for a rendered Vega specification
-  vg2scenegraph
-             Convert a Vega specification to a Vega scenegraph
+  vg2sg      Convert a Vega specification to a Vega scenegraph
   javascript-bundle
              Produce the JavaScript bundle used by Vega Embed integrations
   svg2png    Convert an SVG image to a PNG image

--- a/vl-convert/src/commands.rs
+++ b/vl-convert/src/commands.rs
@@ -581,7 +581,7 @@ pub(crate) enum Commands {
     },
 
     /// Produce the JavaScript bundle used by Vega Embed integrations
-    JavascriptBundle {
+    BundleJs {
         /// Path to a JavaScript snippet to bundle. Reads from stdin if set to "-"
         #[arg(long)]
         snippet: Option<String>,

--- a/vl-convert/src/commands.rs
+++ b/vl-convert/src/commands.rs
@@ -325,7 +325,7 @@ pub(crate) enum Commands {
     },
 
     /// Convert a Vega-Lite specification to a Vega scenegraph
-    Vl2scenegraph {
+    Vl2sg {
         /// Path to input Vega-Lite file. Reads from stdin if omitted or set to "-"
         #[arg(short, long)]
         input: Option<String>,
@@ -551,7 +551,7 @@ pub(crate) enum Commands {
     },
 
     /// Convert a Vega specification to a Vega scenegraph
-    Vg2scenegraph {
+    Vg2sg {
         /// Path to input Vega file. Reads from stdin if omitted or set to "-"
         #[arg(short, long)]
         input: Option<String>,

--- a/vl-convert/src/commands.rs
+++ b/vl-convert/src/commands.rs
@@ -1,6 +1,40 @@
-use clap::Subcommand;
+use clap::{Args, Subcommand, ValueEnum};
 
 use crate::cli_types::DEFAULT_VL_VERSION;
+
+fn parse_non_negative_finite_f32(value: &str) -> Result<f32, String> {
+    let parsed = value
+        .parse::<f32>()
+        .map_err(|err| format!("expected a number: {err}"))?;
+    if !parsed.is_finite() {
+        return Err("value must be finite".to_string());
+    }
+    if parsed < 0.0 {
+        return Err("value must be non-negative".to_string());
+    }
+    Ok(parsed)
+}
+
+#[derive(Debug, Clone, Default, Args)]
+pub(crate) struct RenderOverrides {
+    /// Override the chart width
+    #[arg(long, value_parser = parse_non_negative_finite_f32)]
+    pub width: Option<f32>,
+
+    /// Override the chart height
+    #[arg(long, value_parser = parse_non_negative_finite_f32)]
+    pub height: Option<f32>,
+
+    /// Override the chart background
+    #[arg(long)]
+    pub background: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum ScenegraphFormat {
+    Json,
+    Msgpack,
+}
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
@@ -29,6 +63,9 @@ pub(crate) enum Commands {
         /// Pretty-print JSON in output file
         #[arg(short, long)]
         pretty: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega-Lite specification to an SVG image
@@ -64,6 +101,9 @@ pub(crate) enum Commands {
         /// Bundle fonts and images into a self-contained SVG
         #[arg(long)]
         bundle: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega-Lite specification to an PNG image
@@ -103,6 +143,9 @@ pub(crate) enum Commands {
         /// d3-time-format locale name or file with .json extension
         #[arg(long)]
         time_format_locale: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega-Lite specification to an JPEG image
@@ -142,6 +185,9 @@ pub(crate) enum Commands {
         /// d3-time-format locale name or file with .json extension
         #[arg(long)]
         time_format_locale: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega-Lite specification to a PDF image
@@ -173,6 +219,9 @@ pub(crate) enum Commands {
         /// d3-time-format locale name or file with .json extension
         #[arg(long)]
         time_format_locale: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega-Lite specification to a URL that opens the chart in the Vega editor
@@ -228,6 +277,9 @@ pub(crate) enum Commands {
         /// Vega renderer. One of 'svg' (default), 'canvas', or 'hybrid'
         #[arg(long)]
         renderer: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Return font metadata for a rendered Vega-Lite specification
@@ -267,6 +319,51 @@ pub(crate) enum Commands {
         /// Pretty-print JSON output
         #[arg(short, long)]
         pretty: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
+    },
+
+    /// Convert a Vega-Lite specification to a Vega scenegraph
+    Vl2scenegraph {
+        /// Path to input Vega-Lite file. Reads from stdin if omitted or set to "-"
+        #[arg(short, long)]
+        input: Option<String>,
+
+        /// Path to output scenegraph file. Writes to stdout if omitted or set to "-"
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
+        #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
+        vl_version: String,
+
+        /// Named theme provided by the vegaThemes package (e.g. "dark")
+        #[arg(long)]
+        theme: Option<String>,
+
+        /// Path to Vega-Lite config file
+        #[arg(short, long)]
+        config: Option<String>,
+
+        /// d3-format locale name or file with .json extension
+        #[arg(long)]
+        format_locale: Option<String>,
+
+        /// d3-time-format locale name or file with .json extension
+        #[arg(long)]
+        time_format_locale: Option<String>,
+
+        /// Output format: json or msgpack
+        #[arg(long, value_enum, default_value = "json")]
+        format: ScenegraphFormat,
+
+        /// Pretty-print JSON output
+        #[arg(short, long)]
+        pretty: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega specification to an SVG image
@@ -290,6 +387,9 @@ pub(crate) enum Commands {
         /// Bundle fonts and images into a self-contained SVG
         #[arg(long)]
         bundle: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega specification to an PNG image
@@ -317,6 +417,9 @@ pub(crate) enum Commands {
         /// d3-time-format locale name or file with .json extension
         #[arg(long)]
         time_format_locale: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega specification to an JPEG image
@@ -344,6 +447,9 @@ pub(crate) enum Commands {
         /// d3-time-format locale name or file with .json extension
         #[arg(long)]
         time_format_locale: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega specification to an PDF image
@@ -363,6 +469,9 @@ pub(crate) enum Commands {
         /// d3-time-format locale name or file with .json extension
         #[arg(long)]
         time_format_locale: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Convert a Vega specification to a URL that opens the chart in the Vega editor
@@ -406,6 +515,9 @@ pub(crate) enum Commands {
         /// Vega renderer. One of 'svg' (default), 'canvas', or 'hybrid'
         #[arg(long)]
         renderer: Option<String>,
+
+        #[command(flatten)]
+        render: RenderOverrides,
     },
 
     /// Return font metadata for a rendered Vega specification
@@ -433,6 +545,54 @@ pub(crate) enum Commands {
         /// Pretty-print JSON output
         #[arg(short, long)]
         pretty: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
+    },
+
+    /// Convert a Vega specification to a Vega scenegraph
+    Vg2scenegraph {
+        /// Path to input Vega file. Reads from stdin if omitted or set to "-"
+        #[arg(short, long)]
+        input: Option<String>,
+
+        /// Path to output scenegraph file. Writes to stdout if omitted or set to "-"
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// d3-format locale name or file with .json extension
+        #[arg(long)]
+        format_locale: Option<String>,
+
+        /// d3-time-format locale name or file with .json extension
+        #[arg(long)]
+        time_format_locale: Option<String>,
+
+        /// Output format: json or msgpack
+        #[arg(long, value_enum, default_value = "json")]
+        format: ScenegraphFormat,
+
+        /// Pretty-print JSON output
+        #[arg(short, long)]
+        pretty: bool,
+
+        #[command(flatten)]
+        render: RenderOverrides,
+    },
+
+    /// Produce the JavaScript bundle used by Vega Embed integrations
+    JavascriptBundle {
+        /// Path to a JavaScript snippet to bundle. Reads from stdin if set to "-"
+        #[arg(long)]
+        snippet: Option<String>,
+
+        /// Path to output JavaScript file. Writes to stdout if omitted or set to "-"
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Vega-Lite Version. One of 5.8, 5.14, 5.15, 5.16, 5.17, 5.20, 5.21, 6.1, 6.4
+        #[arg(short, long, default_value = DEFAULT_VL_VERSION)]
+        vl_version: String,
     },
 
     /// Convert an SVG image to a PNG image

--- a/vl-convert/src/handlers.rs
+++ b/vl-convert/src/handlers.rs
@@ -4,10 +4,23 @@ use vl_convert_rs::converter::{
 };
 use vl_convert_rs::{anyhow, anyhow::bail};
 
+use crate::commands::{RenderOverrides, ScenegraphFormat};
 use crate::io_utils::{
     parse_as_json, parse_format_locale_option, parse_time_format_locale_option, parse_vl_version,
     read_config_json, read_input_string, write_output_binary, write_output_string,
 };
+
+fn apply_vl_render_overrides(opts: &mut VlOpts, render: RenderOverrides) {
+    opts.background = render.background;
+    opts.width = render.width;
+    opts.height = render.height;
+}
+
+fn apply_vg_render_overrides(opts: &mut VgOpts, render: RenderOverrides) {
+    opts.background = render.background;
+    opts.width = render.width;
+    opts.height = render.height;
+}
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn vl_2_vg(
@@ -17,6 +30,7 @@ pub(crate) async fn vl_2_vg(
     theme: Option<String>,
     config: Option<String>,
     pretty: bool,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vl_version = parse_vl_version(vl_version)?;
@@ -26,18 +40,15 @@ pub(crate) async fn vl_2_vg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let vega_output = match converter
-        .vegalite_to_vega(
-            vegalite_json,
-            VlOpts {
-                vl_version,
-                theme,
-                config,
-                ..Default::default()
-            },
-        )
-        .await
-    {
+    let mut vl_opts = VlOpts {
+        vl_version,
+        theme,
+        config,
+        ..Default::default()
+    };
+    apply_vl_render_overrides(&mut vl_opts, render);
+
+    let vega_output = match converter.vegalite_to_vega(vegalite_json, vl_opts).await {
         Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to Vega conversion failed: {}", err);
@@ -66,6 +77,7 @@ pub(crate) async fn vg_2_svg(
     format_locale: Option<String>,
     time_format_locale: Option<String>,
     svg_opts: SvgOpts,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vega_str = read_input_string(input)?;
@@ -76,18 +88,14 @@ pub(crate) async fn vg_2_svg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let svg_output = match converter
-        .vega_to_svg(
-            vg_spec,
-            VgOpts {
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
-            svg_opts,
-        )
-        .await
-    {
+    let mut vg_opts = VgOpts {
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vg_render_overrides(&mut vg_opts, render);
+
+    let svg_output = match converter.vega_to_svg(vg_spec, vg_opts, svg_opts).await {
         Ok(output) => output,
         Err(err) => {
             bail!("Vega to SVG conversion failed: {}", err);
@@ -107,6 +115,7 @@ pub(crate) async fn vg_2_png(
     ppi: f32,
     format_locale: Option<String>,
     time_format_locale: Option<String>,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vega_str = read_input_string(input)?;
@@ -117,14 +126,17 @@ pub(crate) async fn vg_2_png(
 
     let converter = VlConverter::with_config(converter_config)?;
 
+    let mut vg_opts = VgOpts {
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vg_render_overrides(&mut vg_opts, render);
+
     let png_output = match converter
         .vega_to_png(
             vg_spec,
-            VgOpts {
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
+            vg_opts,
             PngOpts {
                 scale: Some(scale),
                 ppi: Some(ppi),
@@ -151,6 +163,7 @@ pub(crate) async fn vg_2_jpeg(
     quality: u8,
     format_locale: Option<String>,
     time_format_locale: Option<String>,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vega_str = read_input_string(input)?;
@@ -161,14 +174,17 @@ pub(crate) async fn vg_2_jpeg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
+    let mut vg_opts = VgOpts {
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vg_render_overrides(&mut vg_opts, render);
+
     let jpeg_output = match converter
         .vega_to_jpeg(
             vg_spec,
-            VgOpts {
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
+            vg_opts,
             JpegOpts {
                 scale: Some(scale),
                 quality: Some(quality),
@@ -192,6 +208,7 @@ pub(crate) async fn vg_2_pdf(
     output: Option<&str>,
     format_locale: Option<String>,
     time_format_locale: Option<String>,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vega_str = read_input_string(input)?;
@@ -202,16 +219,15 @@ pub(crate) async fn vg_2_pdf(
 
     let converter = VlConverter::with_config(converter_config)?;
 
+    let mut vg_opts = VgOpts {
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vg_render_overrides(&mut vg_opts, render);
+
     let pdf_output = match converter
-        .vega_to_pdf(
-            vg_spec,
-            VgOpts {
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
-            PdfOpts::default(),
-        )
+        .vega_to_pdf(vg_spec, vg_opts, PdfOpts::default())
         .await
     {
         Ok(output) => output,
@@ -235,6 +251,7 @@ pub(crate) async fn vl_2_svg(
     format_locale: Option<String>,
     time_format_locale: Option<String>,
     svg_opts: SvgOpts,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vl_version = parse_vl_version(vl_version)?;
@@ -247,21 +264,17 @@ pub(crate) async fn vl_2_svg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
-    let svg_output = match converter
-        .vegalite_to_svg(
-            vl_spec,
-            VlOpts {
-                vl_version,
-                config,
-                theme,
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
-            svg_opts,
-        )
-        .await
-    {
+    let mut vl_opts = VlOpts {
+        vl_version,
+        config,
+        theme,
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vl_render_overrides(&mut vl_opts, render);
+
+    let svg_output = match converter.vegalite_to_svg(vl_spec, vl_opts, svg_opts).await {
         Ok(output) => output,
         Err(err) => {
             bail!("Vega-Lite to SVG conversion failed: {}", err);
@@ -284,6 +297,7 @@ pub(crate) async fn vl_2_png(
     ppi: f32,
     format_locale: Option<String>,
     time_format_locale: Option<String>,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vl_version = parse_vl_version(vl_version)?;
@@ -296,17 +310,20 @@ pub(crate) async fn vl_2_png(
 
     let converter = VlConverter::with_config(converter_config)?;
 
+    let mut vl_opts = VlOpts {
+        vl_version,
+        config,
+        theme,
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vl_render_overrides(&mut vl_opts, render);
+
     let png_output = match converter
         .vegalite_to_png(
             vl_spec,
-            VlOpts {
-                vl_version,
-                config,
-                theme,
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
+            vl_opts,
             PngOpts {
                 scale: Some(scale),
                 ppi: Some(ppi),
@@ -336,6 +353,7 @@ pub(crate) async fn vl_2_jpeg(
     quality: u8,
     format_locale: Option<String>,
     time_format_locale: Option<String>,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vl_version = parse_vl_version(vl_version)?;
@@ -348,17 +366,20 @@ pub(crate) async fn vl_2_jpeg(
 
     let converter = VlConverter::with_config(converter_config)?;
 
+    let mut vl_opts = VlOpts {
+        vl_version,
+        config,
+        theme,
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vl_render_overrides(&mut vl_opts, render);
+
     let jpeg_output = match converter
         .vegalite_to_jpeg(
             vl_spec,
-            VlOpts {
-                vl_version,
-                config,
-                theme,
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
+            vl_opts,
             JpegOpts {
                 scale: Some(scale),
                 quality: Some(quality),
@@ -386,6 +407,7 @@ pub(crate) async fn vl_2_pdf(
     config: Option<String>,
     format_locale: Option<String>,
     time_format_locale: Option<String>,
+    render: RenderOverrides,
     converter_config: VlcConfig,
 ) -> Result<(), anyhow::Error> {
     let vl_version = parse_vl_version(vl_version)?;
@@ -398,19 +420,18 @@ pub(crate) async fn vl_2_pdf(
 
     let converter = VlConverter::with_config(converter_config)?;
 
+    let mut vl_opts = VlOpts {
+        vl_version,
+        config,
+        theme,
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vl_render_overrides(&mut vl_opts, render);
+
     let pdf_output = match converter
-        .vegalite_to_pdf(
-            vl_spec,
-            VlOpts {
-                vl_version,
-                config,
-                theme,
-                format_locale,
-                time_format_locale,
-                ..Default::default()
-            },
-            PdfOpts::default(),
-        )
+        .vegalite_to_pdf(vl_spec, vl_opts, PdfOpts::default())
         .await
     {
         Ok(output) => output,
@@ -421,6 +442,132 @@ pub(crate) async fn vl_2_pdf(
 
     write_output_binary(output, &pdf_output.data, "PDF")?;
 
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn vl_2_scenegraph(
+    input: Option<&str>,
+    output: Option<&str>,
+    vl_version: &str,
+    theme: Option<String>,
+    config: Option<String>,
+    format_locale: Option<String>,
+    time_format_locale: Option<String>,
+    format: ScenegraphFormat,
+    pretty: bool,
+    render: RenderOverrides,
+    converter_config: VlcConfig,
+) -> Result<(), anyhow::Error> {
+    if pretty && matches!(format, ScenegraphFormat::Msgpack) {
+        bail!("--pretty is only valid with --format json");
+    }
+
+    let vl_version = parse_vl_version(vl_version)?;
+    let vegalite_str = read_input_string(input)?;
+    let vl_spec = parse_as_json(&vegalite_str)?;
+    let config = read_config_json(config)?;
+
+    let format_locale = parse_format_locale_option(format_locale.as_deref())?;
+    let time_format_locale = parse_time_format_locale_option(time_format_locale.as_deref())?;
+
+    let mut vl_opts = VlOpts {
+        vl_version,
+        config,
+        theme,
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vl_render_overrides(&mut vl_opts, render);
+
+    let converter = VlConverter::with_config(converter_config)?;
+    match format {
+        ScenegraphFormat::Json => {
+            let scenegraph_output = converter.vegalite_to_scenegraph(vl_spec, vl_opts).await?;
+            let json = if pretty {
+                serde_json::to_string_pretty(&scenegraph_output.scenegraph)?
+            } else {
+                serde_json::to_string(&scenegraph_output.scenegraph)?
+            };
+            write_output_string(output, &json)?;
+        }
+        ScenegraphFormat::Msgpack => {
+            let scenegraph_output = converter
+                .vegalite_to_scenegraph_msgpack(vl_spec, vl_opts)
+                .await?;
+            write_output_binary(output, &scenegraph_output.data, "MessagePack")?;
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn vg_2_scenegraph(
+    input: Option<&str>,
+    output: Option<&str>,
+    format_locale: Option<String>,
+    time_format_locale: Option<String>,
+    format: ScenegraphFormat,
+    pretty: bool,
+    render: RenderOverrides,
+    converter_config: VlcConfig,
+) -> Result<(), anyhow::Error> {
+    if pretty && matches!(format, ScenegraphFormat::Msgpack) {
+        bail!("--pretty is only valid with --format json");
+    }
+
+    let vega_str = read_input_string(input)?;
+    let vg_spec = parse_as_json(&vega_str)?;
+
+    let format_locale = parse_format_locale_option(format_locale.as_deref())?;
+    let time_format_locale = parse_time_format_locale_option(time_format_locale.as_deref())?;
+
+    let mut vg_opts = VgOpts {
+        format_locale,
+        time_format_locale,
+        ..Default::default()
+    };
+    apply_vg_render_overrides(&mut vg_opts, render);
+
+    let converter = VlConverter::with_config(converter_config)?;
+    match format {
+        ScenegraphFormat::Json => {
+            let scenegraph_output = converter.vega_to_scenegraph(vg_spec, vg_opts).await?;
+            let json = if pretty {
+                serde_json::to_string_pretty(&scenegraph_output.scenegraph)?
+            } else {
+                serde_json::to_string(&scenegraph_output.scenegraph)?
+            };
+            write_output_string(output, &json)?;
+        }
+        ScenegraphFormat::Msgpack => {
+            let scenegraph_output = converter
+                .vega_to_scenegraph_msgpack(vg_spec, vg_opts)
+                .await?;
+            write_output_binary(output, &scenegraph_output.data, "MessagePack")?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn javascript_bundle(
+    output: Option<&str>,
+    snippet: Option<&str>,
+    vl_version: &str,
+    converter_config: VlcConfig,
+) -> Result<(), anyhow::Error> {
+    let vl_version = parse_vl_version(vl_version)?;
+    let converter = VlConverter::with_config(converter_config)?;
+    let bundle = if let Some(path) = snippet {
+        let snippet = read_input_string(Some(path))?;
+        converter.bundle_vega_snippet(snippet, vl_version).await?
+    } else {
+        converter.get_vegaembed_bundle(vl_version).await?
+    };
+    write_output_string(output, &bundle)?;
     Ok(())
 }
 

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -19,8 +19,8 @@ use vl_convert_rs::{anyhow, anyhow::bail};
 use cli_types::Cli;
 use commands::Commands;
 use handlers::{
-    cat_theme, list_themes, vg_2_jpeg, vg_2_pdf, vg_2_png, vg_2_svg, vl_2_jpeg, vl_2_pdf, vl_2_png,
-    vl_2_svg, vl_2_vg,
+    cat_theme, javascript_bundle, list_themes, vg_2_jpeg, vg_2_pdf, vg_2_png, vg_2_scenegraph,
+    vg_2_svg, vl_2_jpeg, vl_2_pdf, vl_2_png, vl_2_scenegraph, vl_2_svg, vl_2_vg,
 };
 use io_utils::{
     apply_global_font_dirs, apply_global_google_fonts_cache, expand_allowed_base_urls,
@@ -165,6 +165,7 @@ async fn run_command(
             theme,
             config,
             pretty,
+            render,
         } => {
             vl_2_vg(
                 input_vegalite_file.as_deref(),
@@ -173,6 +174,7 @@ async fn run_command(
                 theme,
                 config,
                 pretty,
+                render,
                 base_config,
             )
             .await?
@@ -186,6 +188,7 @@ async fn run_command(
             format_locale,
             time_format_locale,
             bundle,
+            render,
         } => {
             let svg_opts = SvgOpts { bundle };
             vl_2_svg(
@@ -197,6 +200,7 @@ async fn run_command(
                 format_locale,
                 time_format_locale,
                 svg_opts,
+                render,
                 base_config,
             )
             .await?
@@ -211,6 +215,7 @@ async fn run_command(
             ppi,
             format_locale,
             time_format_locale,
+            render,
         } => {
             vl_2_png(
                 input.as_deref(),
@@ -222,6 +227,7 @@ async fn run_command(
                 ppi,
                 format_locale,
                 time_format_locale,
+                render,
                 base_config,
             )
             .await?
@@ -236,6 +242,7 @@ async fn run_command(
             quality,
             format_locale,
             time_format_locale,
+            render,
         } => {
             vl_2_jpeg(
                 input.as_deref(),
@@ -247,6 +254,7 @@ async fn run_command(
                 quality,
                 format_locale,
                 time_format_locale,
+                render,
                 base_config,
             )
             .await?
@@ -259,6 +267,7 @@ async fn run_command(
             config,
             format_locale,
             time_format_locale,
+            render,
         } => {
             vl_2_pdf(
                 input.as_deref(),
@@ -268,6 +277,7 @@ async fn run_command(
                 config,
                 format_locale,
                 time_format_locale,
+                render,
                 base_config,
             )
             .await?
@@ -292,6 +302,7 @@ async fn run_command(
             format_locale,
             time_format_locale,
             renderer,
+            render,
         } => {
             let google_fonts = parse_google_font_requests(&google_font_families)?;
             let vl_str = read_input_string(input.as_deref())?;
@@ -314,6 +325,9 @@ async fn run_command(
                         format_locale,
                         time_format_locale,
                         google_fonts,
+                        background: render.background,
+                        width: render.width,
+                        height: render.height,
                         ..Default::default()
                     },
                     HtmlOpts {
@@ -334,6 +348,7 @@ async fn run_command(
             format_locale,
             time_format_locale,
             pretty,
+            render,
         } => {
             let google_fonts = parse_google_font_requests(&google_font_families)?;
             let vl_str = read_input_string(input.as_deref())?;
@@ -358,6 +373,9 @@ async fn run_command(
                         format_locale,
                         time_format_locale,
                         google_fonts,
+                        background: render.background,
+                        width: render.width,
+                        height: render.height,
                         ..Default::default()
                     },
                     auto_google_fonts,
@@ -373,12 +391,40 @@ async fn run_command(
             };
             write_output_string(output.as_deref(), &json)?;
         }
+        Vl2scenegraph {
+            input,
+            output,
+            vl_version,
+            theme,
+            config,
+            format_locale,
+            time_format_locale,
+            format,
+            pretty,
+            render,
+        } => {
+            vl_2_scenegraph(
+                input.as_deref(),
+                output.as_deref(),
+                &vl_version,
+                theme,
+                config,
+                format_locale,
+                time_format_locale,
+                format,
+                pretty,
+                render,
+                base_config,
+            )
+            .await?
+        }
         Vg2svg {
             input,
             output,
             format_locale,
             bundle,
             time_format_locale,
+            render,
         } => {
             let svg_opts = SvgOpts { bundle };
             vg_2_svg(
@@ -387,6 +433,7 @@ async fn run_command(
                 format_locale,
                 time_format_locale,
                 svg_opts,
+                render,
                 base_config,
             )
             .await?
@@ -398,6 +445,7 @@ async fn run_command(
             ppi,
             format_locale,
             time_format_locale,
+            render,
         } => {
             vg_2_png(
                 input.as_deref(),
@@ -406,6 +454,7 @@ async fn run_command(
                 ppi,
                 format_locale,
                 time_format_locale,
+                render,
                 base_config,
             )
             .await?
@@ -417,6 +466,7 @@ async fn run_command(
             quality,
             format_locale,
             time_format_locale,
+            render,
         } => {
             vg_2_jpeg(
                 input.as_deref(),
@@ -425,6 +475,7 @@ async fn run_command(
                 quality,
                 format_locale,
                 time_format_locale,
+                render,
                 base_config,
             )
             .await?
@@ -434,12 +485,14 @@ async fn run_command(
             output,
             format_locale,
             time_format_locale,
+            render,
         } => {
             vg_2_pdf(
                 input.as_deref(),
                 output.as_deref(),
                 format_locale,
                 time_format_locale,
+                render,
                 base_config,
             )
             .await?
@@ -461,6 +514,7 @@ async fn run_command(
             format_locale,
             time_format_locale,
             renderer,
+            render,
         } => {
             let google_fonts = parse_google_font_requests(&google_font_families)?;
             let vg_str = read_input_string(input.as_deref())?;
@@ -480,6 +534,9 @@ async fn run_command(
                         format_locale,
                         time_format_locale,
                         google_fonts,
+                        background: render.background,
+                        width: render.width,
+                        height: render.height,
                         ..Default::default()
                     },
                     HtmlOpts {
@@ -497,6 +554,7 @@ async fn run_command(
             format_locale,
             time_format_locale,
             pretty,
+            render,
         } => {
             let google_fonts = parse_google_font_requests(&google_font_families)?;
             let vg_str = read_input_string(input.as_deref())?;
@@ -516,6 +574,9 @@ async fn run_command(
                         google_fonts,
                         format_locale,
                         time_format_locale,
+                        background: render.background,
+                        width: render.width,
+                        height: render.height,
                         ..Default::default()
                     },
                     auto_google_fonts,
@@ -530,6 +591,40 @@ async fn run_command(
                 serde_json::to_string(&fonts)?
             };
             write_output_string(output.as_deref(), &json)?;
+        }
+        Vg2scenegraph {
+            input,
+            output,
+            format_locale,
+            time_format_locale,
+            format,
+            pretty,
+            render,
+        } => {
+            vg_2_scenegraph(
+                input.as_deref(),
+                output.as_deref(),
+                format_locale,
+                time_format_locale,
+                format,
+                pretty,
+                render,
+                base_config,
+            )
+            .await?
+        }
+        JavascriptBundle {
+            snippet,
+            output,
+            vl_version,
+        } => {
+            javascript_bundle(
+                output.as_deref(),
+                snippet.as_deref(),
+                &vl_version,
+                base_config,
+            )
+            .await?
         }
         Svg2png {
             input,

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -613,7 +613,7 @@ async fn run_command(
             )
             .await?
         }
-        JavascriptBundle {
+        BundleJs {
             snippet,
             output,
             vl_version,

--- a/vl-convert/src/main.rs
+++ b/vl-convert/src/main.rs
@@ -391,7 +391,7 @@ async fn run_command(
             };
             write_output_string(output.as_deref(), &json)?;
         }
-        Vl2scenegraph {
+        Vl2sg {
             input,
             output,
             vl_version,
@@ -592,7 +592,7 @@ async fn run_command(
             };
             write_output_string(output.as_deref(), &json)?;
         }
-        Vg2scenegraph {
+        Vg2sg {
             input,
             output,
             format_locale,

--- a/vl-convert/tests/test_formats.rs
+++ b/vl-convert/tests/test_formats.rs
@@ -56,6 +56,16 @@ const TIME_TEXT_SPEC: &str = r#"{
   }
 }"#;
 
+const SIMPLE_VL_SPEC: &str = r#"{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {"values": [{"category": "A", "value": 1}]},
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "category", "type": "nominal"},
+    "y": {"field": "value", "type": "quantitative"}
+  }
+}"#;
+
 fn write_temp_json(contents: &str) -> Result<NamedTempFile, Box<dyn std::error::Error>> {
     let mut file = tempfile::Builder::new().suffix(".json").tempfile()?;
     file.write_all(contents.as_bytes())?;
@@ -136,6 +146,39 @@ fn default_time_locale_accepts_inline_json_and_file() -> Result<(), Box<dyn std:
         "file default time-format locale was not applied; SVG:\n{file_svg}"
     );
 
+    Ok(())
+}
+
+#[test]
+fn vl2vg_render_overrides_set_top_level_properties() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let spec = write_temp_json(SIMPLE_VL_SPEC)?;
+    let mut cmd = vl_convert_cmd()?;
+    let output = cmd
+        .arg("--vlc-config")
+        .arg("disabled")
+        .arg("vl2vg")
+        .arg("-i")
+        .arg(spec.path())
+        .arg("--width")
+        .arg("321")
+        .arg("--height")
+        .arg("123")
+        .arg("--background")
+        .arg("#abcdef")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "vl2vg failed with status {:?}; stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let spec: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(spec["width"], 321);
+    assert_eq!(spec["height"], 123);
+    assert_eq!(spec["background"], "#abcdef");
     Ok(())
 }
 

--- a/vl-convert/tests/test_javascript_bundling.rs
+++ b/vl-convert/tests/test_javascript_bundling.rs
@@ -1,0 +1,52 @@
+mod common;
+
+use common::*;
+
+#[test]
+fn javascript_bundle_outputs_default_bundle() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let mut cmd = vl_convert_cmd()?;
+    let output = cmd
+        .arg("--vlc-config")
+        .arg("disabled")
+        .arg("javascript-bundle")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "javascript-bundle failed with status {:?}; stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bundle = String::from_utf8(output.stdout)?;
+    assert!(bundle.contains("vegaEmbed"));
+    Ok(())
+}
+
+#[test]
+fn javascript_bundle_wraps_snippet() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let mut snippet = NamedTempFile::new()?;
+    snippet.write_all(b"console.log('vlc javascript bundling marker');")?;
+
+    let mut cmd = vl_convert_cmd()?;
+    let output = cmd
+        .arg("--vlc-config")
+        .arg("disabled")
+        .arg("javascript-bundle")
+        .arg("--snippet")
+        .arg(snippet.path())
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "javascript-bundle --snippet failed with status {:?}; stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bundle = String::from_utf8(output.stdout)?;
+    assert!(bundle.contains("vlc javascript bundling marker"));
+    Ok(())
+}

--- a/vl-convert/tests/test_javascript_bundling.rs
+++ b/vl-convert/tests/test_javascript_bundling.rs
@@ -10,12 +10,12 @@ fn javascript_bundle_outputs_default_bundle() -> Result<(), Box<dyn std::error::
     let output = cmd
         .arg("--vlc-config")
         .arg("disabled")
-        .arg("javascript-bundle")
+        .arg("bundle-js")
         .output()?;
 
     assert!(
         output.status.success(),
-        "javascript-bundle failed with status {:?}; stderr:\n{}",
+        "bundle-js failed with status {:?}; stderr:\n{}",
         output.status,
         String::from_utf8_lossy(&output.stderr)
     );
@@ -35,14 +35,14 @@ fn javascript_bundle_wraps_snippet() -> Result<(), Box<dyn std::error::Error>> {
     let output = cmd
         .arg("--vlc-config")
         .arg("disabled")
-        .arg("javascript-bundle")
+        .arg("bundle-js")
         .arg("--snippet")
         .arg(snippet.path())
         .output()?;
 
     assert!(
         output.status.success(),
-        "javascript-bundle --snippet failed with status {:?}; stderr:\n{}",
+        "bundle-js --snippet failed with status {:?}; stderr:\n{}",
         output.status,
         String::from_utf8_lossy(&output.stderr)
     );

--- a/vl-convert/tests/test_scenegraph.rs
+++ b/vl-convert/tests/test_scenegraph.rs
@@ -1,0 +1,92 @@
+mod common;
+
+use common::*;
+use std::process::{Command, Output, Stdio};
+
+const SIMPLE_VL_SPEC: &str = r#"{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {"values": [{"category": "A", "value": 1}]},
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "category", "type": "nominal"},
+    "y": {"field": "value", "type": "quantitative"}
+  }
+}"#;
+
+fn run_with_stdin(
+    cmd: &mut Command,
+    stdin_text: &str,
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("stdin must be piped");
+    stdin.write_all(stdin_text.as_bytes())?;
+    drop(stdin);
+    Ok(child.wait_with_output()?)
+}
+
+#[test]
+fn vl2scenegraph_outputs_json() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let mut cmd = vl_convert_cmd()?;
+    cmd.arg("--vlc-config").arg("disabled").arg("vl2scenegraph");
+    let output = run_with_stdin(&mut cmd, SIMPLE_VL_SPEC)?;
+
+    assert!(
+        output.status.success(),
+        "vl2scenegraph failed with status {:?}; stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let scenegraph: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert!(scenegraph.is_object(), "expected scenegraph object");
+    Ok(())
+}
+
+#[test]
+fn vg2scenegraph_outputs_msgpack() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let mut cmd = vl_convert_cmd()?;
+    let output = cmd
+        .arg("--vlc-config")
+        .arg("disabled")
+        .arg("vg2scenegraph")
+        .arg("--format")
+        .arg("msgpack")
+        .arg("-i")
+        .arg(vg_spec_path("label_scatter_plot"))
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "vg2scenegraph --format msgpack failed with status {:?}; stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let scenegraph: serde_json::Value = rmp_serde::from_slice(&output.stdout)?;
+    assert!(scenegraph.is_object(), "expected scenegraph object");
+    Ok(())
+}
+
+#[test]
+fn scenegraph_pretty_rejects_msgpack() -> Result<(), Box<dyn std::error::Error>> {
+    initialize();
+
+    let mut cmd = vl_convert_cmd()?;
+    cmd.arg("--vlc-config")
+        .arg("disabled")
+        .arg("vl2scenegraph")
+        .arg("--format")
+        .arg("msgpack")
+        .arg("--pretty");
+    let output = run_with_stdin(&mut cmd, SIMPLE_VL_SPEC)?;
+    assert!(!output.status.success(), "expected command to fail");
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("--pretty is only valid with --format json"));
+    Ok(())
+}

--- a/vl-convert/tests/test_scenegraph.rs
+++ b/vl-convert/tests/test_scenegraph.rs
@@ -29,16 +29,16 @@ fn run_with_stdin(
 }
 
 #[test]
-fn vl2scenegraph_outputs_json() -> Result<(), Box<dyn std::error::Error>> {
+fn vl2sg_outputs_json() -> Result<(), Box<dyn std::error::Error>> {
     initialize();
 
     let mut cmd = vl_convert_cmd()?;
-    cmd.arg("--vlc-config").arg("disabled").arg("vl2scenegraph");
+    cmd.arg("--vlc-config").arg("disabled").arg("vl2sg");
     let output = run_with_stdin(&mut cmd, SIMPLE_VL_SPEC)?;
 
     assert!(
         output.status.success(),
-        "vl2scenegraph failed with status {:?}; stderr:\n{}",
+        "vl2sg failed with status {:?}; stderr:\n{}",
         output.status,
         String::from_utf8_lossy(&output.stderr)
     );
@@ -48,14 +48,14 @@ fn vl2scenegraph_outputs_json() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn vg2scenegraph_outputs_msgpack() -> Result<(), Box<dyn std::error::Error>> {
+fn vg2sg_outputs_msgpack() -> Result<(), Box<dyn std::error::Error>> {
     initialize();
 
     let mut cmd = vl_convert_cmd()?;
     let output = cmd
         .arg("--vlc-config")
         .arg("disabled")
-        .arg("vg2scenegraph")
+        .arg("vg2sg")
         .arg("--format")
         .arg("msgpack")
         .arg("-i")
@@ -64,7 +64,7 @@ fn vg2scenegraph_outputs_msgpack() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(
         output.status.success(),
-        "vg2scenegraph --format msgpack failed with status {:?}; stderr:\n{}",
+        "vg2sg --format msgpack failed with status {:?}; stderr:\n{}",
         output.status,
         String::from_utf8_lossy(&output.stderr)
     );
@@ -80,7 +80,7 @@ fn scenegraph_pretty_rejects_msgpack() -> Result<(), Box<dyn std::error::Error>>
     let mut cmd = vl_convert_cmd()?;
     cmd.arg("--vlc-config")
         .arg("disabled")
-        .arg("vl2scenegraph")
+        .arg("vl2sg")
         .arg("--format")
         .arg("msgpack")
         .arg("--pretty");


### PR DESCRIPTION
## Summary

This PR fills several API parity gaps across the CLI and server surfaces. One motivation is to make it simpler to document the different APIs, but these are also generally useful.

The CLI now exposes scenegraph conversion directly through `vl2sg` and `vg2sg`. JSON is the default output format, and `--format msgpack` provides the binary MessagePack path already available through the Rust, Python, and server APIs. The scenegraph commands accept the same conversion controls as the neighboring Vega/Vega-Lite commands, including locale options and render overrides.

The CLI also gains `bundle-js`, which mirrors the existing bundle APIs by either producing the default Vega Embed bundle or bundling a caller-provided snippet via `--snippet <path|->`.

For render options, Vega and Vega-Lite CLI conversion commands backed by `VlOpts` / `VgOpts` now accept `--width`, `--height`, and `--background`, so callers can apply per-conversion overrides without editing the spec.

On the server side, the admin surface now includes `GET /admin/diagnostics/workers` for per-worker V8 heap statistics. `/infoz` also includes the local timezone used by Vega, cached at startup so the health/info endpoint does not query workers per request.

