### PR TITLE
Remove deprecated Python PDF scale parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9692,6 +9698,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10562,6 +10580,7 @@ dependencies = [
  "sys_traits",
  "tempfile",
  "tiny-skia",
+ "tiny_http",
  "tokio",
  "ttf-parser",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tiny-skia = "0.11.4"
 tinyvec = "1"
 tokio = { version = "1.36", features = ["macros", "rt-multi-thread", "signal"] }
 ttf-parser = "0.25.1"
+tiny_http = "0.12"
 urlencoding = "2"
 usvg = "0.45.1"
 zip-extract = "0.4.0"

--- a/vl-convert-python/src/conversions.rs
+++ b/vl-convert-python/src/conversions.rs
@@ -4,7 +4,7 @@ use crate::utils::{
     async_variant_doc, future_into_py_object, handle_show_warnings, parse_json_spec,
     parse_option_format_locale, parse_option_time_format_locale, parse_optional_config,
     parse_spec_to_value_or_string, prefixed_py_error, run_converter_future,
-    run_converter_future_async, warn_if_scale_not_one_for_pdf,
+    run_converter_future_async,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -830,7 +830,6 @@ pub fn vegalite_to_jpeg(
 ///
 /// Args:
 ///     vg_spec (str | dict): Vega JSON specification string or dict
-///     scale (float): Image scale factor (default 1.0)
 ///     format_locale (str | dict): d3-format locale name or dictionary
 ///     time_format_locale (str | dict): d3-time-format locale name or dictionary
 ///     vega_plugin (str): Per-request Vega plugin (inline ESM string or URL)
@@ -845,7 +844,6 @@ pub fn vegalite_to_jpeg(
 #[pyo3(signature = (
     vg_spec,
     *,
-    scale=None,
     format_locale=None,
     time_format_locale=None,
     vega_plugin=None,
@@ -857,7 +855,6 @@ pub fn vegalite_to_jpeg(
 ))]
 pub fn vega_to_pdf(
     vg_spec: PyObject,
-    scale: Option<f32>,
     format_locale: Option<PyObject>,
     time_format_locale: Option<PyObject>,
     vega_plugin: Option<String>,
@@ -867,7 +864,6 @@ pub fn vega_to_pdf(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<PyObject> {
-    warn_if_scale_not_one_for_pdf(scale)?;
     let vg_spec = parse_json_spec(vg_spec)?;
     let format_locale = parse_option_format_locale(format_locale)?;
     let time_format_locale = parse_option_time_format_locale(time_format_locale)?;
@@ -907,7 +903,6 @@ pub fn vega_to_pdf(
 ///     vl_spec (str | dict): Vega-Lite JSON specification string or dict
 ///     vl_version (str): Vega-Lite library version string (e.g. 'v5.15')
 ///         (default to latest)
-///     scale (float): Image scale factor (default 1.0)
 ///     config (dict | None): Chart configuration object to apply during conversion
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
 ///     format_locale (str | dict): d3-format locale name or dictionary
@@ -924,7 +919,6 @@ pub fn vega_to_pdf(
     vl_spec,
     *,
     vl_version=None,
-    scale=None,
     config=None,
     theme=None,
     format_locale=None,
@@ -938,7 +932,6 @@ pub fn vega_to_pdf(
 pub fn vegalite_to_pdf(
     vl_spec: PyObject,
     vl_version: Option<&str>,
-    scale: Option<f32>,
     config: Option<PyObject>,
     theme: Option<String>,
     format_locale: Option<PyObject>,
@@ -949,7 +942,6 @@ pub fn vegalite_to_pdf(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<PyObject> {
-    warn_if_scale_not_one_for_pdf(scale)?;
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
     } else {
@@ -1246,13 +1238,11 @@ pub fn svg_to_jpeg(svg: &str, scale: Option<f32>, quality: Option<u8>) -> PyResu
 ///
 /// Args:
 ///     svg (str): SVG image string
-///     scale (float): Image scale factor (default 1.0)
 /// Returns:
 ///     bytes: PDF document data
 #[pyfunction]
-#[pyo3(signature = (svg, *, scale=None))]
-pub fn svg_to_pdf(svg: &str, scale: Option<f32>) -> PyResult<PyObject> {
-    warn_if_scale_not_one_for_pdf(scale)?;
+#[pyo3(signature = (svg))]
+pub fn svg_to_pdf(svg: &str) -> PyResult<PyObject> {
     let svg = svg.to_string();
     let pdf_data = run_converter_future(move |converter| async move {
         converter
@@ -1918,7 +1908,6 @@ pub fn vegalite_to_jpeg_asyncio<'py>(
 #[pyo3(signature = (
     vg_spec,
     *,
-    scale=None,
     format_locale=None,
     time_format_locale=None,
     vega_plugin=None,
@@ -1931,7 +1920,6 @@ pub fn vegalite_to_jpeg_asyncio<'py>(
 pub fn vega_to_pdf_asyncio<'py>(
     py: Python<'py>,
     vg_spec: PyObject,
-    scale: Option<f32>,
     format_locale: Option<PyObject>,
     time_format_locale: Option<PyObject>,
     vega_plugin: Option<String>,
@@ -1941,7 +1929,6 @@ pub fn vega_to_pdf_asyncio<'py>(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    warn_if_scale_not_one_for_pdf(scale)?;
     let vg_spec = parse_json_spec(vg_spec)?;
     let format_locale = parse_option_format_locale(format_locale)?;
     let time_format_locale = parse_option_time_format_locale(time_format_locale)?;
@@ -1978,7 +1965,6 @@ pub fn vega_to_pdf_asyncio<'py>(
     vl_spec,
     *,
     vl_version=None,
-    scale=None,
     config=None,
     theme=None,
     format_locale=None,
@@ -1993,7 +1979,6 @@ pub fn vegalite_to_pdf_asyncio<'py>(
     py: Python<'py>,
     vl_spec: PyObject,
     vl_version: Option<&str>,
-    scale: Option<f32>,
     config: Option<PyObject>,
     theme: Option<String>,
     format_locale: Option<PyObject>,
@@ -2004,7 +1989,6 @@ pub fn vegalite_to_pdf_asyncio<'py>(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    warn_if_scale_not_one_for_pdf(scale)?;
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
     } else {
@@ -2297,13 +2281,8 @@ pub fn svg_to_jpeg_asyncio<'py>(
 
 #[doc = async_variant_doc!("svg_to_pdf")]
 #[pyfunction(name = "svg_to_pdf")]
-#[pyo3(signature = (svg, *, scale=None))]
-pub fn svg_to_pdf_asyncio<'py>(
-    py: Python<'py>,
-    svg: &str,
-    scale: Option<f32>,
-) -> PyResult<Bound<'py, PyAny>> {
-    warn_if_scale_not_one_for_pdf(scale)?;
+#[pyo3(signature = (svg))]
+pub fn svg_to_pdf_asyncio<'py>(py: Python<'py>, svg: &str) -> PyResult<Bound<'py, PyAny>> {
     let svg = svg.to_string();
     run_converter_future_async(
         py,

--- a/vl-convert-python/src/utils.rs
+++ b/vl-convert-python/src/utils.rs
@@ -221,19 +221,3 @@ pub fn parse_embedded_locale_json(raw: &str, kind: &str) -> PyResult<serde_json:
         PyValueError::new_err(format!("Failed to parse internal {kind} as JSON: {err}"))
     })
 }
-
-pub fn warn_if_scale_not_one_for_pdf(scale: Option<f32>) -> PyResult<()> {
-    if let Some(scale) = scale {
-        if scale != 1.0 {
-            Python::with_gil(|py| -> PyResult<()> {
-                let warnings = py.import("warnings")?;
-                warnings.call_method1(
-                    "warn",
-                    ("The scale argument is no longer supported for PDF export.",),
-                )?;
-                Ok(())
-            })?;
-        }
-    }
-    Ok(())
-}

--- a/vl-convert-python/tests/test_asyncio.py
+++ b/vl-convert-python/tests/test_asyncio.py
@@ -93,6 +93,21 @@ def test_asyncio_smoke_and_sync_parity_shapes():
     run(scenario())
 
 
+def test_asyncio_pdf_rejects_scale_keyword():
+    async def scenario():
+        vega = await vlca.vegalite_to_vega(SIMPLE_VL_SPEC, vl_version="v5_16")
+        svg = await vlca.vegalite_to_svg(SIMPLE_VL_SPEC, vl_version="v5_16")
+
+        with pytest.raises(TypeError):
+            await vlca.vega_to_pdf(vega, scale=2)
+        with pytest.raises(TypeError):
+            await vlca.vegalite_to_pdf(SIMPLE_VL_SPEC, vl_version="v5_16", scale=2)
+        with pytest.raises(TypeError):
+            await vlca.svg_to_pdf(svg, scale=2)
+
+    run(scenario())
+
+
 def test_asyncio_parallel_gather_with_workers():
     async def scenario():
         await vlca.configure(num_workers=4)

--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -365,6 +365,20 @@ def test_pdf(name, tol, as_dict):
     check_png(png, expected_png, tol=tol, name=f"pdf_vegalite_{name}")
 
 
+def test_pdf_rejects_scale_keyword():
+    vl_version = "v5_8"
+    vl_spec = load_vl_spec("circle_binned")
+    vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
+    svg = vlc.vegalite_to_svg(vl_spec, vl_version=vl_version)
+
+    with pytest.raises(TypeError):
+        vlc.vega_to_pdf(vg_spec, scale=2)
+    with pytest.raises(TypeError):
+        vlc.vegalite_to_pdf(vl_spec, vl_version=vl_version, scale=2)
+    with pytest.raises(TypeError):
+        vlc.svg_to_pdf(svg, scale=2)
+
+
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Font mismatch on windows")
 def test_locale():
     vl_version = "v5_8"

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -637,7 +637,7 @@ def svg_to_jpeg(
     """
     ...
 
-def svg_to_pdf(svg: str, *, scale: float | None = None) -> bytes:
+def svg_to_pdf(svg: str) -> bytes:
     """
     Convert an SVG image string to PDF document data.
 
@@ -645,8 +645,6 @@ def svg_to_pdf(svg: str, *, scale: float | None = None) -> bytes:
     ----------
     svg
         SVG image string
-    scale
-        Image scale factor (default 1.0)
 
     Returns
     -------
@@ -777,7 +775,6 @@ def vega_to_jpeg(
 def vega_to_pdf(
     vg_spec: VlSpec,
     *,
-    scale: float | None = None,
     format_locale: FormatLocale | None = None,
     time_format_locale: TimeFormatLocale | None = None,
     vega_plugin: str | None = None,
@@ -794,8 +791,6 @@ def vega_to_pdf(
     ----------
     vg_spec
         Vega JSON specification string or dict
-    scale
-        Image scale factor (default 1.0)
     format_locale
         d3-format locale name or dictionary
     time_format_locale
@@ -1170,7 +1165,7 @@ def vegalite_to_jpeg(
         Override the spec's height.
     Returns
     -------
-    JPEG image data.
+    PDF file bytes.
     """
     ...
 
@@ -1178,7 +1173,6 @@ def vegalite_to_pdf(
     vl_spec: VlSpec,
     *,
     vl_version: str | None = None,
-    scale: float | None = None,
     config: dict[str, Any] | None = None,
     theme: VegaThemes | None = None,
     format_locale: FormatLocale | None = None,
@@ -1199,8 +1193,6 @@ def vegalite_to_pdf(
     vl_version
         Vega-Lite library version string (e.g. 'v5.15')
         (default to latest)
-    scale
-        Image scale factor (default 1.0)
     config
         Chart configuration object to apply during conversion
     theme
@@ -1566,7 +1558,7 @@ if TYPE_CHECKING:
         ) -> bytes:
             """Async version of ``svg_to_jpeg``. See sync function for full documentation."""
             ...
-        async def svg_to_pdf(self, svg: str, *, scale: float | None = None) -> bytes:
+        async def svg_to_pdf(self, svg: str) -> bytes:
             """Async version of ``svg_to_pdf``. See sync function for full documentation."""
             ...
         async def svg_to_png(
@@ -1612,7 +1604,6 @@ if TYPE_CHECKING:
             self,
             vg_spec: VlSpec,
             *,
-            scale: float | None = None,
             format_locale: FormatLocale | None = None,
             time_format_locale: TimeFormatLocale | None = None,
             vega_plugin: str | None = None,
@@ -1747,7 +1738,6 @@ if TYPE_CHECKING:
             vl_spec: VlSpec,
             *,
             vl_version: str | None = None,
-            scale: float | None = None,
             config: dict[str, Any] | None = None,
             theme: VegaThemes | None = None,
             format_locale: FormatLocale | None = None,

--- a/vl-convert-rs/Cargo.toml
+++ b/vl-convert-rs/Cargo.toml
@@ -68,6 +68,7 @@ winapi = { version = "0.3", features = ["std"] }
 [dev-dependencies]
 rstest = { workspace = true }
 dssim = { workspace = true }
+tiny_http = { workspace = true }
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]

--- a/vl-convert-rs/src/converter/inner/mod.rs
+++ b/vl-convert-rs/src/converter/inner/mod.rs
@@ -347,13 +347,14 @@ pub(super) mod tests {
 
     pub(in crate::converter) struct TestHttpServer {
         addr: std::net::SocketAddr,
+        server: Arc<tiny_http::Server>,
         running: Arc<std::sync::atomic::AtomicBool>,
         handle: Option<std::thread::JoinHandle<()>>,
     }
 
     impl TestHttpServer {
         pub(in crate::converter) fn new(routes: Vec<(&str, TestHttpResponse)>) -> Self {
-            let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+            let server = Arc::new(tiny_http::Server::http("127.0.0.1:0").unwrap());
             let addr = server.server_addr().to_ip().expect("test server binds TCP");
 
             let routes = Arc::new(
@@ -365,10 +366,11 @@ pub(super) mod tests {
             let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
             let running_clone = running.clone();
             let routes_clone = routes.clone();
+            let server_clone = server.clone();
 
             let handle = std::thread::spawn(move || {
                 while running_clone.load(std::sync::atomic::Ordering::SeqCst) {
-                    match server.recv_timeout(std::time::Duration::from_millis(100)) {
+                    match server_clone.recv_timeout(std::time::Duration::from_millis(100)) {
                         Ok(Some(request)) => handle_test_http_request(request, &routes_clone),
                         Ok(None) => continue,
                         Err(_) => break,
@@ -378,6 +380,7 @@ pub(super) mod tests {
 
             Self {
                 addr,
+                server,
                 running,
                 handle: Some(handle),
             }
@@ -401,7 +404,7 @@ pub(super) mod tests {
         fn drop(&mut self) {
             self.running
                 .store(false, std::sync::atomic::Ordering::SeqCst);
-            let _ = std::net::TcpStream::connect(self.addr);
+            self.server.unblock();
             if let Some(handle) = self.handle.take() {
                 let _ = handle.join();
             }

--- a/vl-convert-rs/src/converter/inner/mod.rs
+++ b/vl-convert-rs/src/converter/inner/mod.rs
@@ -353,9 +353,11 @@ pub(super) mod tests {
 
     impl TestHttpServer {
         pub(in crate::converter) fn new(routes: Vec<(&str, TestHttpResponse)>) -> Self {
-            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-            listener.set_nonblocking(true).unwrap();
-            let addr = listener.local_addr().unwrap();
+            let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+            let addr = match server.server_addr() {
+                tiny_http::ListenAddr::IP(addr) => addr,
+                tiny_http::ListenAddr::Unix(_) => unreachable!("test server binds TCP"),
+            };
 
             let routes = Arc::new(
                 routes
@@ -369,13 +371,9 @@ pub(super) mod tests {
 
             let handle = std::thread::spawn(move || {
                 while running_clone.load(std::sync::atomic::Ordering::SeqCst) {
-                    match listener.accept() {
-                        Ok((stream, _)) => {
-                            handle_test_http_connection(stream, &routes_clone);
-                        }
-                        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                            std::thread::sleep(std::time::Duration::from_millis(5));
-                        }
+                    match server.recv_timeout(std::time::Duration::from_millis(100)) {
+                        Ok(Some(request)) => handle_test_http_request(request, &routes_clone),
+                        Ok(None) => continue,
                         Err(_) => break,
                     }
                 }
@@ -413,34 +411,15 @@ pub(super) mod tests {
         }
     }
 
-    fn handle_test_http_connection(
-        mut stream: std::net::TcpStream,
+    fn handle_test_http_request(
+        request: tiny_http::Request,
         routes: &std::collections::HashMap<String, TestHttpResponse>,
     ) {
-        use std::io::{BufRead, BufReader, Write};
-
-        let Ok(reader_stream) = stream.try_clone() else {
-            return;
-        };
-        let mut reader = BufReader::new(reader_stream);
-
-        let mut request_line = String::new();
-        if reader.read_line(&mut request_line).is_err() {
-            return;
-        }
-        let request_target = request_line.split_whitespace().nth(1).unwrap_or("/");
-        let request_path = request_target.split('?').next().unwrap_or(request_target);
-
-        loop {
-            let mut header_line = String::new();
-            if reader.read_line(&mut header_line).is_err() {
-                return;
-            }
-            if header_line == "\r\n" || header_line == "\n" || header_line.is_empty() {
-                break;
-            }
-        }
-
+        let request_path = request
+            .url()
+            .split('?')
+            .next()
+            .unwrap_or_else(|| request.url());
         let response = routes
             .get(request_path)
             .cloned()
@@ -450,60 +429,14 @@ pub(super) mod tests {
                 body: b"not found".to_vec(),
             });
 
-        let mut headers = response.headers;
-        if !headers
-            .iter()
-            .any(|(name, _)| name.eq_ignore_ascii_case("content-length"))
-        {
-            headers.push((
-                "Content-Length".to_string(),
-                response.body.len().to_string(),
-            ));
+        let mut tiny_response = tiny_http::Response::from_data(response.body)
+            .with_status_code(tiny_http::StatusCode(response.status));
+        for (name, value) in response.headers {
+            let header = tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes())
+                .unwrap_or_else(|_| panic!("invalid test response header {name}: {value}"));
+            tiny_response.add_header(header);
         }
-        if !headers
-            .iter()
-            .any(|(name, _)| name.eq_ignore_ascii_case("connection"))
-        {
-            headers.push(("Connection".to_string(), "close".to_string()));
-        }
-
-        let mut response_head = format!(
-            "HTTP/1.1 {} {}\r\n",
-            response.status,
-            http_reason_phrase(response.status)
-        );
-        for (name, value) in headers {
-            response_head.push_str(&format!("{name}: {value}\r\n"));
-        }
-        response_head.push_str("\r\n");
-
-        let _ = stream.write_all(response_head.as_bytes());
-        let _ = stream.write_all(&response.body);
-        let _ = stream.flush();
-
-        let _ = stream.shutdown(std::net::Shutdown::Write);
-        let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
-        let mut drain_buf = [0u8; 256];
-        loop {
-            use std::io::Read;
-            match stream.read(&mut drain_buf) {
-                Ok(0) | Err(_) => break,
-                Ok(_) => continue,
-            }
-        }
-    }
-
-    fn http_reason_phrase(status: u16) -> &'static str {
-        match status {
-            200 => "OK",
-            301 => "Moved Permanently",
-            302 => "Found",
-            303 => "See Other",
-            307 => "Temporary Redirect",
-            308 => "Permanent Redirect",
-            404 => "Not Found",
-            _ => "Status",
-        }
+        let _ = request.respond(tiny_response);
     }
 
     #[tokio::test]

--- a/vl-convert-rs/src/converter/inner/mod.rs
+++ b/vl-convert-rs/src/converter/inner/mod.rs
@@ -354,10 +354,7 @@ pub(super) mod tests {
     impl TestHttpServer {
         pub(in crate::converter) fn new(routes: Vec<(&str, TestHttpResponse)>) -> Self {
             let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
-            let addr = match server.server_addr() {
-                tiny_http::ListenAddr::IP(addr) => addr,
-                tiny_http::ListenAddr::Unix(_) => unreachable!("test server binds TCP"),
-            };
+            let addr = server.server_addr().to_ip().expect("test server binds TCP");
 
             let routes = Arc::new(
                 routes

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -335,7 +335,6 @@ mod test_vegalite_to_vega {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::VlOpts;
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(
@@ -380,7 +379,6 @@ mod test_vegalite_to_html_no_bundle {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::{HtmlOpts, Renderer, VlOpts};
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(
@@ -428,7 +426,6 @@ mod test_vegalite_to_html_bundle {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::{HtmlOpts, Renderer, VlOpts};
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(
@@ -475,7 +472,6 @@ mod test_svg {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::VlOpts;
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(
@@ -522,7 +518,6 @@ mod test_svg_allowed_base_url {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::{SvgOpts, VgOpts, VlOpts, VlcConfig};
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(#[values("circle_binned")] name: &str) {
@@ -609,7 +604,6 @@ mod test_scenegraph {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::VlOpts;
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(
@@ -651,7 +645,6 @@ mod test_png_no_theme {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::VlOpts;
-    use vl_convert_rs::VlConverter;
 
     #[rstest(name, scale, dssim_threshold,
         case("circle_binned", 1.0, DEFAULT_THRESHOLD),
@@ -715,7 +708,6 @@ mod test_png_google_fonts {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::{GoogleFontRequest, VlcConfig, VlOpts};
-    use vl_convert_rs::VlConverter;
 
     #[test]
     fn test() {
@@ -754,7 +746,6 @@ mod test_png_theme_config {
     use futures::executor::block_on;
     use serde_json::json;
     use vl_convert_rs::converter::VlOpts;
-    use vl_convert_rs::VlConverter;
 
     #[rstest(name, scale, theme,
     case("circle_binned", 1.0, "dark"),
@@ -910,7 +901,6 @@ mod test_jpeg {
     use crate::*;
     use futures::executor::block_on;
     use vl_convert_rs::converter::VlOpts;
-    use vl_convert_rs::VlConverter;
 
     #[rstest]
     fn test(
@@ -957,7 +947,6 @@ mod test_jpeg {
 mod test_vega_label_transform {
     use crate::*;
     use futures::executor::block_on;
-    use vl_convert_rs::VlConverter;
 
     #[rstest(name, scale,
         case("label_transform_test", 1.0),

--- a/vl-convert/README.md
+++ b/vl-convert/README.md
@@ -190,8 +190,6 @@ Options:
           Named theme provided by the vegaThemes package (e.g. "dark")
   -c, --config <CONFIG>
           Path to Vega-Lite config file. Defaults to ~/.config/vl-convert/config.json
-      --scale <SCALE>
-          Image scale factor [default: 1.0]
       --show-warnings
           Whether to show Vega-Lite compilation warnings
       --font-dir <FONT_DIR>
@@ -207,10 +205,10 @@ Options:
 
 ```
 
-For example, convert a Vega-Lite specification file named `in.vl.json` into a PNG file named `out.pdf` with a scale factor of 2.
+For example, convert a Vega-Lite specification file named `in.vl.json` into a PDF file named `out.pdf`.
 
 ```
-$ vl-convert vl2pdf -i ./in.vl.json -o ./out.pdf --scale 2
+$ vl-convert vl2pdf -i ./in.vl.json -o ./out.pdf
 ```
 
 ### vl2url
@@ -340,8 +338,6 @@ Options:
           Path to input Vega file
   -o, --output <OUTPUT>
           Path to output PDF file to be created
-  -s, --scale <SCALE>
-          Image scale factor [default: 1.0]
       --font-dir <FONT_DIR>
           Additional directory to search for fonts
   -a, --allowed-base-url <ALLOWED_BASE_URL>
@@ -354,10 +350,10 @@ Options:
           Print help
 ```
 
-For example, convert a Vega specification file named `in.vg.json` into a PDF file named `out.pdf` with a scale factor of 2.
+For example, convert a Vega specification file named `in.vg.json` into a PDF file named `out.pdf`.
 
 ```plain
-$ vl-convert vg2pdf -i ./in.vg.json -o ./out.pdf --scale 2
+$ vl-convert vg2pdf -i ./in.vg.json -o ./out.pdf
 ```
 
 ### vg2url
@@ -443,7 +439,6 @@ Usage: vl-convert svg2pdf [OPTIONS] --input <INPUT> --output <OUTPUT>
 Options:
   -i, --input <INPUT>        Path to input SVG file
   -o, --output <OUTPUT>      Path to output PDF file to be created
-      --scale <SCALE>        Image scale factor [default: 1.0]
       --font-dir <FONT_DIR>  Additional directory to search for fonts
   -h, --help                 Print help
 ```


### PR DESCRIPTION
## Summary

Remove the deprecated Python-only `scale` keyword from PDF conversion APIs. PDF output is vector output produced through the SVG-to-PDF path, so the old parameter was a compatibility shim that warned for non-`1.0` values and did not affect the result.

The sync and asyncio Python bindings, `vl_convert.pyi` signatures, and tests now treat `scale` as an unexpected keyword for `vega_to_pdf`, `vegalite_to_pdf`, and `svg_to_pdf`. The CLI README examples no longer show PDF commands with `--scale`.

The converter test HTTP fixture now uses `tiny_http` instead of a hand-rolled TCP accept loop, which keeps the URL allowlist tests closer to normal HTTP behavior while staying test-only.