### PR TITLE
ci: publish packages from GitHub Releases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,11 @@ jobs:
           pixi-version: v0.47.0
       - name: Check cargo fmt compliance
         run: pixi run fmt-py-check
+      - name: Check release automation
+        run: |
+          pixi run fmt-release-check
+          pixi run lint-release
+          pixi run check-workspace
 
   # Run on Linux without Pixi due to glibc linker issues with conda toolchain
   rust-fmt-clippy:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       linux_wheels_only:
@@ -12,330 +11,848 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  RUST_VERSION: 1.95.0
+  MATURIN_VERSION: 1.8.6
+
 jobs:
-  build-cli-linux-x86:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+  validate:
+    name: Validate release source
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      python_version: ${{ steps.metadata.outputs.python_version }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      source_ref: ${{ steps.metadata.outputs.source_ref }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Install latest stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install protoc
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install release validation dependency
+        run: python -m pip install packaging==23.2
+      - name: Fetch main for release ancestry check
+        if: github.event_name == 'release'
+        run: git fetch origin main:refs/remotes/origin/main
+      - name: Validate release metadata
+        id: metadata
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          sudo apt-get update
-          sudo apt-get install protobuf-compiler
+          python scripts/check_workspace.py
+          version=$(python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
+          python_version=$(VERSION="$version" python -c 'import os; from packaging.version import Version; print(Version(os.environ["VERSION"]))')
+          tag="v${version}"
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            if [[ "$RELEASE_TAG" != "$tag" ]]; then
+              echo "Release tag $RELEASE_TAG must equal $tag" >&2
+              exit 1
+            fi
+            prerelease=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq .prerelease)
+            expected_prerelease=false
+            if [[ "$version" == *-* ]]; then
+              expected_prerelease=true
+            fi
+            if [[ "$prerelease" != "$expected_prerelease" ]]; then
+              echo "GitHub prerelease is $prerelease; expected $expected_prerelease" >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor HEAD refs/remotes/origin/main; then
+              echo "The release commit is not reachable from origin/main" >&2
+              exit 1
+            fi
+          fi
+          {
+            printf 'version=%s\n' "$version"
+            printf 'python_version=%s\n' "$python_version"
+            printf 'tag=%s\n' "$tag"
+            printf 'source_ref=%s\n' "$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
+  build-cli-linux-x86:
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "24.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build vl-convert
-        run: |
-          cargo build --release -p vl-convert
-      - name: Move executable to bin directory
+        run: cargo build --release --locked -p vl-convert
+      - name: Verify version
+        run: test "$(target/release/vl-convert --version)" = "vl-convert ${EXPECTED_VERSION}"
+      - name: Package executable
         run: |
           mkdir -p bin
           cp target/release/vl-convert bin/
-          cp LICENSE bin/
-          cp thirdparty_* bin/
+          cp LICENSE thirdparty_* bin/
           zip -r vl-convert_linux-64.zip bin/
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vl-convert-linux-x86
-          path: |
-            vl-convert_linux-64.zip
+          name: cli-linux-x86
+          path: vl-convert_linux-64.zip
+          if-no-files-found: error
+          overwrite: true
 
   build-cli-linux-aarch64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: ubuntu-24.04-arm
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Install latest stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install protobuf-compiler
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "24.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build vl-convert
-        run: |
-          cargo build --release -p vl-convert
-      - name: Move executable to bin directory
+        run: cargo build --release --locked -p vl-convert
+      - name: Verify version
+        run: test "$(target/release/vl-convert --version)" = "vl-convert ${EXPECTED_VERSION}"
+      - name: Package executable
         run: |
           mkdir -p bin
           cp target/release/vl-convert bin/
-          cp LICENSE bin/
-          cp thirdparty_* bin/
+          cp LICENSE thirdparty_* bin/
           zip -r vl-convert_linux-aarch64.zip bin/
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vl-convert-linux-aarch64
-          path: |
-            vl-convert_linux-aarch64.zip
+          name: cli-linux-aarch64
+          path: vl-convert_linux-aarch64.zip
+          if-no-files-found: error
+          overwrite: true
 
   build-cli-win-64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: windows-2022
     env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
       RUST_MIN_STACK: 8388608
     steps:
       - name: Enable long paths
         run: git config --system core.longpaths true
-      - uses: actions/checkout@v7
-      - name: Install latest stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "24.0"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # NASM is needed on Windows to compile aws-lc-rs (x86 assembly optimizations),
-      # pulled in via deno_runtime -> deno_tls -> rustls -> aws-lc-rs
       - name: Install NASM
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+        with:
+          version: 2.16.01
       - name: Build vl-convert
+        run: cargo build --release --locked -p vl-convert
+      - name: Verify version
         run: |
-          cargo build --release -p vl-convert
-      - name: Move executable to bin directory
+          $actual = & target\release\vl-convert.exe --version
+          if ($actual -ne "vl-convert $env:EXPECTED_VERSION") {
+            throw "Expected vl-convert $env:EXPECTED_VERSION, found $actual"
+          }
+      - name: Package executable
         run: |
           New-Item -Path "artifacts\bin" -ItemType Directory
           Copy-Item "target\release\vl-convert.exe" -Destination "artifacts\bin"
           Copy-Item "LICENSE" -Destination "artifacts\bin"
           Copy-Item "thirdparty_*" -Destination "artifacts\bin"
-      - name: zip executable
-        uses: vimtor/action-zip@v1
+          Compress-Archive -Path "artifacts\*" -DestinationPath "vl-convert_win-64.zip"
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          files: artifacts/
-          dest: vl-convert_win-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: vl-convert-win-64
-          path: |
-            vl-convert_win-64.zip
+          name: cli-win-64
+          path: vl-convert_win-64.zip
+          if-no-files-found: error
+          overwrite: true
 
   build-cli-osx-64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: macos-15-intel
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Install latest stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "24.0"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build vl-convert
-        run: |
-          cargo build --release -p vl-convert
-      - name: Move executable to bin directory
+        run: cargo build --release --locked -p vl-convert
+      - name: Verify version
+        run: test "$(target/release/vl-convert --version)" = "vl-convert ${EXPECTED_VERSION}"
+      - name: Package executable
         run: |
           mkdir -p bin
           cp target/release/vl-convert bin/
-          cp LICENSE bin/
-          cp thirdparty_* bin/
+          cp LICENSE thirdparty_* bin/
           zip -r vl-convert_osx-64.zip bin/
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vl-convert-osx-64
-          path: |
-            vl-convert_osx-64.zip
+          name: cli-osx-64
+          path: vl-convert_osx-64.zip
+          if-no-files-found: error
+          overwrite: true
 
   build-cli-osx-arm64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: macos-14
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Install latest stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "24.0"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build vl-convert
-        run: |
-          cargo build --release -p vl-convert
-      - name: Move executable to bin directory
+        run: cargo build --release --locked -p vl-convert
+      - name: Verify version
+        run: test "$(target/release/vl-convert --version)" = "vl-convert ${EXPECTED_VERSION}"
+      - name: Package executable
         run: |
           mkdir -p bin
           cp target/release/vl-convert bin/
-          cp LICENSE bin/
-          cp thirdparty_* bin/
+          cp LICENSE thirdparty_* bin/
           zip -r vl-convert_osx-arm64.zip bin/
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vl-convert-osx-arm64
-          path: |
-            vl-convert_osx-arm64.zip
+          name: cli-osx-arm64
+          path: vl-convert_osx-arm64.zip
+          if-no-files-found: error
+          overwrite: true
 
   build-wheels-linux-x86_64:
+    needs: validate
     runs-on: ubuntu-latest
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: messense/maturin-action@v1.51.0
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Build wheel and source distribution
+        uses: messense/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_VERSION }}
           manylinux: 2_28
           target: x86_64-unknown-linux-gnu
           command: build
-          args: --release -m vl-convert-python/Cargo.toml --sdist -o dist --strip
+          args: --release --locked -m vl-convert-python/Cargo.toml --sdist -o dist --strip
           before-script-linux: |
-            # Install build dependencies
             dnf install -y glib2-devel libffi-devel clang-devel || yum install -y glib2-devel libffi-devel clang-devel
-
-            # Install protoc
             PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-            curl -LO $PB_REL/download/v24.0/protoc-24.0-linux-x86_64.zip
+            curl -LO "$PB_REL/download/v24.0/protoc-24.0-linux-x86_64.zip"
             unzip protoc-24.0-linux-x86_64.zip -d /usr/
-
       - name: Test wheel
         run: |
-          docker run --rm -v $(pwd)/dist:/dist -e RUST_BACKTRACE=1 python:3.11-slim \
-            bash -c "pip install /dist/*x86_64*.whl && python -c \"import vl_convert as vlc; themes = vlc.get_themes(); assert 'dark' in themes, f'dark theme not found in {themes}'; print('Wheel test passed: found', len(themes), 'themes including dark')\""
+          docker run --rm -v "${PWD}/dist:/dist" \
+            -e EXPECTED_VERSION -e EXPECTED_PYTHON_VERSION python:3.11-slim \
+            bash -c "pip install /dist/*x86_64*.whl && python -c \"import importlib.metadata as md, os, vl_convert as vlc; assert md.version('vl-convert-python') == os.environ['EXPECTED_PYTHON_VERSION']; assert vlc.__version__ == os.environ['EXPECTED_VERSION']; themes = vlc.get_themes(); assert 'dark' in themes\""
+      - name: Verify source distribution metadata
+        run: |
+          python - <<'PY'
+          import email
+          import os
+          import tarfile
+          from pathlib import Path
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v7
+          archives = list(Path("dist").glob("*.tar.gz"))
+          if len(archives) != 1:
+              raise SystemExit(f"Expected one source distribution, found {archives}")
+          with tarfile.open(archives[0]) as archive:
+              members = [m for m in archive.getmembers() if m.name.endswith("/PKG-INFO")]
+              if len(members) != 1:
+                  raise SystemExit(f"Expected one PKG-INFO, found {len(members)}")
+              metadata = email.message_from_binary_file(archive.extractfile(members[0]))
+          if metadata["Version"] != os.environ["EXPECTED_PYTHON_VERSION"]:
+              raise SystemExit(
+                  f"Expected {os.environ['EXPECTED_PYTHON_VERSION']}, found {metadata['Version']}"
+              )
+          PY
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-x86_64
-          path: dist
+          name: python-linux-x86_64
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
 
   build-wheels-linux-aarch64:
+    needs: validate
     runs-on: ubuntu-24.04-arm
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: messense/maturin-action@v1.51.0
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Build wheel
+        uses: messense/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_VERSION }}
           manylinux: 2_28
           target: aarch64-unknown-linux-gnu
           command: build
-          args: --release -m vl-convert-python/Cargo.toml -o dist --strip
+          args: --release --locked -m vl-convert-python/Cargo.toml -o dist --strip
           before-script-linux: |
-            # Install build dependencies
             dnf install -y glib2-devel libffi-devel clang-devel || yum install -y glib2-devel libffi-devel clang-devel
-
-            # Install protoc
             PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-            curl -LO $PB_REL/download/v24.0/protoc-24.0-linux-aarch_64.zip
+            curl -LO "$PB_REL/download/v24.0/protoc-24.0-linux-aarch_64.zip"
             unzip protoc-24.0-linux-aarch_64.zip -d /usr/
-
       - name: Test wheel
         run: |
-          docker run --rm -v $(pwd)/dist:/dist -e RUST_BACKTRACE=1 python:3.11-slim \
-            bash -c "pip install /dist/*aarch64*.whl && python -c \"import vl_convert as vlc; themes = vlc.get_themes(); assert 'dark' in themes, f'dark theme not found in {themes}'; print('Wheel test passed: found', len(themes), 'themes including dark')\""
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v7
+          docker run --rm -v "${PWD}/dist:/dist" \
+            -e EXPECTED_VERSION -e EXPECTED_PYTHON_VERSION python:3.11-slim \
+            bash -c "pip install /dist/*aarch64*.whl && python -c \"import importlib.metadata as md, os, vl_convert as vlc; assert md.version('vl-convert-python') == os.environ['EXPECTED_PYTHON_VERSION']; assert vlc.__version__ == os.environ['EXPECTED_VERSION']; themes = vlc.get_themes(); assert 'dark' in themes\""
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-aarch64
-          path: dist
+          name: python-linux-aarch64
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
 
   build-wheels-win-64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: windows-latest
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
+      RUST_MIN_STACK: 8388608
     steps:
       - name: Enable long paths
         run: git config --system core.longpaths true
-      - uses: actions/checkout@v7
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.10"
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
+          version: "24.0"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # NASM is needed on Windows to compile aws-lc-rs (x86 assembly optimizations),
-      # pulled in via deno_runtime -> deno_tls -> rustls -> aws-lc-rs
       - name: Install NASM
-        uses: ilammy/setup-nasm@v1
-      - uses: messense/maturin-action@v1.51.0
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
         with:
+          version: 2.16.01
+      - name: Build wheel
+        uses: messense/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_VERSION }}
           command: build
-          args: --release -m vl-convert-python/Cargo.toml -o dist --strip
+          args: --release --locked -m vl-convert-python/Cargo.toml -o dist --strip
       - name: Test wheel
         run: |
           pip install (Get-ChildItem dist/*.whl)
-          python -c "import vl_convert as vlc; themes = vlc.get_themes(); assert 'dark' in themes, f'dark theme not found in {themes}'; print('Wheel test passed: found', len(themes), 'themes including dark')"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v7
+          python -c "import importlib.metadata as md, os, vl_convert as vlc; assert md.version('vl-convert-python') == os.environ['EXPECTED_PYTHON_VERSION']; assert vlc.__version__ == os.environ['EXPECTED_VERSION']; themes = vlc.get_themes(); assert 'dark' in themes"
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-win-64
-          path: dist
+          name: python-win-64
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
 
   build-wheels-osx-64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: macos-15-intel
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
-      - name: Build Intel wheels
-        uses: messense/maturin-action@v1.51.0
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
+          version: "24.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build wheel
+        uses: messense/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_VERSION }}
           command: build
-          args: --release -m vl-convert-python/Cargo.toml -i python3.10 -o dist --strip
+          args: --release --locked -m vl-convert-python/Cargo.toml -i python3.10 -o dist --strip
           target: x86_64-apple-darwin
       - name: Test wheel
         run: |
           pip install dist/*.whl
-          python -c "import vl_convert as vlc; themes = vlc.get_themes(); assert 'dark' in themes, f'dark theme not found in {themes}'; print('Wheel test passed: found', len(themes), 'themes including dark')"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v7
+          python -c "import importlib.metadata as md, os, vl_convert as vlc; assert md.version('vl-convert-python') == os.environ['EXPECTED_PYTHON_VERSION']; assert vlc.__version__ == os.environ['EXPECTED_VERSION']; themes = vlc.get_themes(); assert 'dark' in themes"
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-osx-64
-          path: dist
+          name: python-osx-64
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
 
   build-wheels-osx-arm64:
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
     runs-on: macos-14
+    env:
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
-      - name: Build arm64 wheels
-        uses: messense/maturin-action@v1.51.0
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
+          version: "24.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build wheel
+        uses: messense/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_VERSION }}
           command: build
-          args: --release -m vl-convert-python/Cargo.toml -i python3.10 -o dist --strip
+          args: --release --locked -m vl-convert-python/Cargo.toml -i python3.10 -o dist --strip
       - name: Test wheel
         run: |
           pip install dist/*.whl
-          python -c "import vl_convert as vlc; themes = vlc.get_themes(); assert 'dark' in themes, f'dark theme not found in {themes}'; print('Wheel test passed: found', len(themes), 'themes including dark')"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v7
+          python -c "import importlib.metadata as md, os, vl_convert as vlc; assert md.version('vl-convert-python') == os.environ['EXPECTED_PYTHON_VERSION']; assert vlc.__version__ == os.environ['EXPECTED_VERSION']; themes = vlc.get_themes(); assert 'dark' in themes"
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-osx-arm64
-          path: dist
+          name: python-osx-arm64
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
+
+  rust-package-preflight:
+    if: ${{ github.event_name == 'release' || !inputs.linux_wheels_only }}
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "24.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify Rust packages
+        run: >-
+          cargo publish --workspace
+          --exclude vl-convert-python
+          --exclude vl-convert-vendor
+          --dry-run --locked
+
+  assemble-artifacts:
+    name: Assemble release artifacts
+    needs:
+      - validate
+      - build-cli-linux-x86
+      - build-cli-linux-aarch64
+      - build-cli-win-64
+      - build-cli-osx-64
+      - build-cli-osx-arm64
+      - build-wheels-linux-x86_64
+      - build-wheels-linux-aarch64
+      - build-wheels-win-64
+      - build-wheels-osx-64
+      - build-wheels-osx-arm64
+      - rust-package-preflight
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
+    steps:
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cli-*
+          path: incoming/
+      - name: Download Python artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: python-*
+          path: incoming/
+      - name: Verify and assemble artifacts
+        run: |
+          python - <<'PY'
+          import hashlib
+          import os
+          import shutil
+          from collections import Counter
+          from pathlib import Path
+
+          version = os.environ["EXPECTED_PYTHON_VERSION"]
+          expected = {
+              "vl-convert_linux-64.zip",
+              "vl-convert_linux-aarch64.zip",
+              "vl-convert_osx-64.zip",
+              "vl-convert_osx-arm64.zip",
+              "vl-convert_win-64.zip",
+              f"vl_convert_python-{version}-cp39-abi3-macosx_10_12_x86_64.whl",
+              f"vl_convert_python-{version}-cp39-abi3-macosx_11_0_arm64.whl",
+              f"vl_convert_python-{version}-cp39-abi3-manylinux_2_28_aarch64.whl",
+              f"vl_convert_python-{version}-cp39-abi3-manylinux_2_28_x86_64.whl",
+              f"vl_convert_python-{version}-cp39-abi3-win_amd64.whl",
+              f"vl_convert_python-{version}.tar.gz",
+          }
+          files = [path for path in Path("incoming").rglob("*") if path.is_file()]
+          actual = Counter(path.name for path in files)
+          wanted = Counter(expected)
+          if actual != wanted:
+              missing = sorted((wanted - actual).elements())
+              extra = sorted((actual - wanted).elements())
+              raise SystemExit(f"Artifact mismatch; missing={missing}, extra={extra}")
+
+          output = Path("release-dist")
+          output.mkdir()
+          for path in files:
+              shutil.copy2(path, output / path.name)
+          with (output / "SHA256SUMS").open("w", encoding="utf-8") as checksums:
+              for name in sorted(expected):
+                  digest = hashlib.sha256((output / name).read_bytes()).hexdigest()
+                  checksums.write(f"{digest}  {name}\n")
+          PY
+      - name: Upload assembled artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-assets
+          path: release-dist/
+          if-no-files-found: error
+          overwrite: true
+
+  publish-crates:
+    name: Publish to crates.io
+    if: github.event_name == 'release'
+    needs: [validate, assemble-artifacts]
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://crates.io/crates/vl-convert
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Authenticate to crates.io
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+      - name: Publish Rust packages
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          packages=(
+            vl-convert
+            vl-convert-canvas2d
+            vl-convert-canvas2d-deno
+            vl-convert-google-fonts
+            vl-convert-rs
+            vl-convert-server
+          )
+          existing=()
+          unpublished=()
+          for package in "${packages[@]}"; do
+            status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              --user-agent vl-convert-release-workflow \
+              "https://crates.io/api/v1/crates/${package}/${VERSION}")
+            case "$status" in
+              200) existing+=("$package") ;;
+              404) unpublished+=("$package") ;;
+              *)
+                echo "crates.io returned HTTP $status for $package $VERSION" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          if (( RUN_ATTEMPT == 1 && ${#existing[@]} > 0 )); then
+            printf 'Version %s already exists for:' "$VERSION" >&2
+            printf ' %s' "${existing[@]}" >&2
+            printf '\n' >&2
+            exit 1
+          fi
+          if (( ${#unpublished[@]} == 0 )); then
+            echo "All Rust packages at $VERSION are already published"
+            exit 0
+          fi
+
+          args=(
+            publish
+            --workspace
+            --exclude vl-convert-python
+            --exclude vl-convert-vendor
+            --locked
+            --no-verify
+          )
+          for package in "${existing[@]}"; do
+            args+=(--exclude "$package")
+          done
+          printf 'Publishing Rust packages at %s:' "$VERSION"
+          printf ' %s' "${unpublished[@]}"
+          printf '\n'
+          cargo "${args[@]}"
 
   publish-pypi:
     name: Publish to PyPI
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.linux_wheels_only }}
-    environment: PyPI Upload
+    if: github.event_name == 'release'
+    needs: [validate, assemble-artifacts]
     runs-on: ubuntu-latest
-    needs:
-      [
-        build-wheels-linux-x86_64,
-        build-wheels-linux-aarch64,
-        build-wheels-win-64,
-        build-wheels-osx-64,
-        build-wheels-osx-arm64,
-      ]
+    environment:
+      name: release
+      url: https://pypi.org/project/vl-convert-python/
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - name: Download assembled artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: wheels-*
-          path: dist/
-          merge-multiple: true
-      - name: Publish to PyPI
-        uses: messense/maturin-action@v1.51.0
+          name: release-assets
+          path: release-assets/
+      - name: Select Python distributions
+        run: |
+          mkdir dist
+          cp release-assets/*.whl release-assets/*.tar.gz dist/
+      - name: Publish Python distributions
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/
+          skip-existing: ${{ github.run_attempt > 1 }}
+
+  upload-release-assets:
+    name: Upload GitHub Release assets
+    if: github.event_name == 'release'
+    needs: [validate, publish-crates, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download assembled artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-assets
+          path: release-assets/
+      - name: Upload release assets
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --skip-existing dist/*
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+
+  verify-release:
+    name: Verify published release
+    if: github.event_name == 'release'
+    needs: [validate, publish-crates, publish-pypi, upload-release-assets]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify registries and GitHub assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          tag = os.environ["RELEASE_TAG"]
+          version = os.environ["VERSION"]
+          python_version = os.environ["PYTHON_VERSION"]
+          crates = (
+              "vl-convert",
+              "vl-convert-canvas2d",
+              "vl-convert-canvas2d-deno",
+              "vl-convert-google-fonts",
+              "vl-convert-rs",
+              "vl-convert-server",
+          )
+
+          def request_json(url, headers=None, attempts=1):
+              request = urllib.request.Request(
+                  url,
+                  headers={"User-Agent": "vl-convert-release-workflow", **(headers or {})},
+              )
+              for attempt in range(attempts):
+                  try:
+                      with urllib.request.urlopen(request, timeout=30) as response:
+                          return json.load(response)
+                  except urllib.error.HTTPError as error:
+                      if error.code != 404 or attempt == attempts - 1:
+                          raise
+                      time.sleep(10)
+
+          for crate in crates:
+              crate_url = (
+                  "https://crates.io/api/v1/crates/"
+                  f"{urllib.parse.quote(crate)}/{urllib.parse.quote(version)}"
+              )
+              request_json(crate_url, attempts=12)
+
+          pypi = request_json(
+              "https://pypi.org/pypi/vl-convert-python/"
+              f"{urllib.parse.quote(python_version)}/json",
+              attempts=12,
+          )
+          expected_distributions = {
+              f"vl_convert_python-{python_version}-cp39-abi3-macosx_10_12_x86_64.whl",
+              f"vl_convert_python-{python_version}-cp39-abi3-macosx_11_0_arm64.whl",
+              f"vl_convert_python-{python_version}-cp39-abi3-manylinux_2_28_aarch64.whl",
+              f"vl_convert_python-{python_version}-cp39-abi3-manylinux_2_28_x86_64.whl",
+              f"vl_convert_python-{python_version}-cp39-abi3-win_amd64.whl",
+              f"vl_convert_python-{python_version}.tar.gz",
+          }
+          actual_distributions = {item["filename"] for item in pypi["urls"]}
+          if actual_distributions != expected_distributions:
+              raise SystemExit(
+                  f"PyPI file mismatch: expected {sorted(expected_distributions)}, "
+                  f"found {sorted(actual_distributions)}"
+              )
+
+          release = request_json(
+              f"https://api.github.com/repos/{repository}/releases/tags/"
+              f"{urllib.parse.quote(tag)}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          expected_assets = expected_distributions | {
+              "SHA256SUMS",
+              "vl-convert_linux-64.zip",
+              "vl-convert_linux-aarch64.zip",
+              "vl-convert_osx-64.zip",
+              "vl-convert_osx-arm64.zip",
+              "vl-convert_win-64.zip",
+          }
+          actual_assets = {asset["name"] for asset in release["assets"]}
+          if actual_assets != expected_assets:
+              raise SystemExit(
+                  f"GitHub asset mismatch: expected {sorted(expected_assets)}, "
+                  f"found {sorted(actual_assets)}"
+              )
+          print(f"Verified {tag} on crates.io, PyPI, and GitHub")
+          PY

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -327,27 +327,6 @@ jobs:
           docker run --rm -v "${PWD}/dist:/dist" \
             -e EXPECTED_VERSION -e EXPECTED_PYTHON_VERSION python:3.11-slim \
             bash -c "pip install /dist/*x86_64*.whl && python -c \"import importlib.metadata as md, os, vl_convert as vlc; assert md.version('vl-convert-python') == os.environ['EXPECTED_PYTHON_VERSION']; assert vlc.__version__ == os.environ['EXPECTED_VERSION']; themes = vlc.get_themes(); assert 'dark' in themes\""
-      - name: Verify source distribution metadata
-        run: |
-          python - <<'PY'
-          import email
-          import os
-          import tarfile
-          from pathlib import Path
-
-          archives = list(Path("dist").glob("*.tar.gz"))
-          if len(archives) != 1:
-              raise SystemExit(f"Expected one source distribution, found {archives}")
-          with tarfile.open(archives[0]) as archive:
-              members = [m for m in archive.getmembers() if m.name.endswith("/PKG-INFO")]
-              if len(members) != 1:
-                  raise SystemExit(f"Expected one PKG-INFO, found {len(members)}")
-              metadata = email.message_from_binary_file(archive.extractfile(members[0]))
-          if metadata["Version"] != os.environ["EXPECTED_PYTHON_VERSION"]:
-              raise SystemExit(
-                  f"Expected {os.environ['EXPECTED_PYTHON_VERSION']}, found {metadata['Version']}"
-              )
-          PY
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -571,6 +550,11 @@ jobs:
     env:
       EXPECTED_PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
     steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.source_ref }}
+          persist-credentials: false
       - name: Download CLI artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -582,45 +566,7 @@ jobs:
           pattern: python-*
           path: incoming/
       - name: Verify and assemble artifacts
-        run: |
-          python - <<'PY'
-          import hashlib
-          import os
-          import shutil
-          from collections import Counter
-          from pathlib import Path
-
-          version = os.environ["EXPECTED_PYTHON_VERSION"]
-          expected = {
-              "vl-convert_linux-64.zip",
-              "vl-convert_linux-aarch64.zip",
-              "vl-convert_osx-64.zip",
-              "vl-convert_osx-arm64.zip",
-              "vl-convert_win-64.zip",
-              f"vl_convert_python-{version}-cp39-abi3-macosx_10_12_x86_64.whl",
-              f"vl_convert_python-{version}-cp39-abi3-macosx_11_0_arm64.whl",
-              f"vl_convert_python-{version}-cp39-abi3-manylinux_2_28_aarch64.whl",
-              f"vl_convert_python-{version}-cp39-abi3-manylinux_2_28_x86_64.whl",
-              f"vl_convert_python-{version}-cp39-abi3-win_amd64.whl",
-              f"vl_convert_python-{version}.tar.gz",
-          }
-          files = [path for path in Path("incoming").rglob("*") if path.is_file()]
-          actual = Counter(path.name for path in files)
-          wanted = Counter(expected)
-          if actual != wanted:
-              missing = sorted((wanted - actual).elements())
-              extra = sorted((actual - wanted).elements())
-              raise SystemExit(f"Artifact mismatch; missing={missing}, extra={extra}")
-
-          output = Path("release-dist")
-          output.mkdir()
-          for path in files:
-              shutil.copy2(path, output / path.name)
-          with (output / "SHA256SUMS").open("w", encoding="utf-8") as checksums:
-              for name in sorted(expected):
-                  digest = hashlib.sha256((output / name).read_bytes()).hexdigest()
-                  checksums.write(f"{digest}  {name}\n")
-          PY
+        run: python scripts/assemble_release_artifacts.py "$EXPECTED_PYTHON_VERSION" incoming release-dist
       - name: Upload assembled artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -755,104 +701,3 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
-
-  verify-release:
-    name: Verify published release
-    if: github.event_name == 'release'
-    needs: [validate, publish-crates, publish-pypi, upload-release-assets]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify registries and GitHub assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
-          VERSION: ${{ needs.validate.outputs.version }}
-          PYTHON_VERSION: ${{ needs.validate.outputs.python_version }}
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          import time
-          import urllib.error
-          import urllib.parse
-          import urllib.request
-
-          repository = os.environ["GITHUB_REPOSITORY"]
-          tag = os.environ["RELEASE_TAG"]
-          version = os.environ["VERSION"]
-          python_version = os.environ["PYTHON_VERSION"]
-          crates = (
-              "vl-convert",
-              "vl-convert-canvas2d",
-              "vl-convert-canvas2d-deno",
-              "vl-convert-google-fonts",
-              "vl-convert-rs",
-              "vl-convert-server",
-          )
-
-          def request_json(url, headers=None, attempts=1):
-              request = urllib.request.Request(
-                  url,
-                  headers={"User-Agent": "vl-convert-release-workflow", **(headers or {})},
-              )
-              for attempt in range(attempts):
-                  try:
-                      with urllib.request.urlopen(request, timeout=30) as response:
-                          return json.load(response)
-                  except urllib.error.HTTPError as error:
-                      if error.code != 404 or attempt == attempts - 1:
-                          raise
-                      time.sleep(10)
-
-          for crate in crates:
-              crate_url = (
-                  "https://crates.io/api/v1/crates/"
-                  f"{urllib.parse.quote(crate)}/{urllib.parse.quote(version)}"
-              )
-              request_json(crate_url, attempts=12)
-
-          pypi = request_json(
-              "https://pypi.org/pypi/vl-convert-python/"
-              f"{urllib.parse.quote(python_version)}/json",
-              attempts=12,
-          )
-          expected_distributions = {
-              f"vl_convert_python-{python_version}-cp39-abi3-macosx_10_12_x86_64.whl",
-              f"vl_convert_python-{python_version}-cp39-abi3-macosx_11_0_arm64.whl",
-              f"vl_convert_python-{python_version}-cp39-abi3-manylinux_2_28_aarch64.whl",
-              f"vl_convert_python-{python_version}-cp39-abi3-manylinux_2_28_x86_64.whl",
-              f"vl_convert_python-{python_version}-cp39-abi3-win_amd64.whl",
-              f"vl_convert_python-{python_version}.tar.gz",
-          }
-          actual_distributions = {item["filename"] for item in pypi["urls"]}
-          if actual_distributions != expected_distributions:
-              raise SystemExit(
-                  f"PyPI file mismatch: expected {sorted(expected_distributions)}, "
-                  f"found {sorted(actual_distributions)}"
-              )
-
-          release = request_json(
-              f"https://api.github.com/repos/{repository}/releases/tags/"
-              f"{urllib.parse.quote(tag)}",
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              },
-          )
-          expected_assets = expected_distributions | {
-              "SHA256SUMS",
-              "vl-convert_linux-64.zip",
-              "vl-convert_linux-aarch64.zip",
-              "vl-convert_osx-64.zip",
-              "vl-convert_osx-arm64.zip",
-              "vl-convert_win-64.zip",
-          }
-          actual_assets = {asset["name"] for asset in release["assets"]}
-          if actual_assets != expected_assets:
-              raise SystemExit(
-                  f"GitHub asset mismatch: expected {sorted(expected_assets)}, "
-                  f"found {sorted(actual_assets)}"
-              )
-          print(f"Verified {tag} on crates.io, PyPI, and GitHub")
-          PY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Rust library + CLI + Python bindings for converting Vega-Lite to static images (
 
 ## Architecture
 
-```
+```text
 vl-convert-rs/      Core Rust library (Deno v8 for JS execution)
 vl-convert/         CLI wrapper
 vl-convert-python/  Python bindings (PyO3/maturin)
@@ -50,11 +50,10 @@ pixi run bundle-licenses # Bundle Rust licenses for Python wheels
 
 ## Release Process
 
-```bash
-cargo ws publish --all --force "vl-convert*" --allow-branch main custom X.Y.Z
-```
-
-CI publishes to PyPI after manual approval.
+Use `pixi run prepare-release <NEXT_VERSION>` to create the release branch and
+draft pull request. After that pull request merges, publish a GitHub Release to
+start package publication. See `DEVELOP.md` for setup, verification, and
+recovery instructions.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,7 @@ pixi run bundle-licenses # Bundle Rust licenses for Python wheels
 
 ## Release Process
 
-Use `pixi run prepare-release <NEXT_VERSION>` to create the release branch and
-draft pull request. After that pull request merges, publish a GitHub Release to
-start package publication. See `DEVELOP.md` for setup, verification, and
-recovery instructions.
+Use `pixi run prepare-release <NEXT_VERSION>` to create the release branch and draft pull request. After that pull request merges, publish a GitHub Release to start package publication. See `DEVELOP.md` for setup, verification, and recovery instructions.
 
 ## Configuration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11041,7 +11041,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-vendor"
-version = "2.0.0-rc2"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "dircpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ members = [
     "vl-convert-server",
 ]
 
+[workspace.package]
+version = "2.0.0-rc2"
+edition = "2021"
+license = "BSD-3-Clause"
+repository = "https://github.com/vega/vl-convert"
+
 [profile.release]
 strip = true  # Automatically strip symbols from the binary
 opt-level = "z"  # Optimize for size
@@ -24,6 +30,13 @@ anyhow = "1.0"
 assert_cmd = "2.0"
 backon = { version = "1", default-features = false, features = ["tokio-sleep", "std", "std-blocking-sleep"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+
+# Internal packages are released in lockstep.
+vl-convert-canvas2d = { path = "vl-convert-canvas2d", version = "=2.0.0-rc2" }
+vl-convert-canvas2d-deno = { path = "vl-convert-canvas2d-deno", version = "=2.0.0-rc2" }
+vl-convert-google-fonts = { path = "vl-convert-google-fonts", version = "=2.0.0-rc2" }
+vl-convert-rs = { path = "vl-convert-rs", version = "=2.0.0-rc2" }
+vl-convert-server = { path = "vl-convert-server", version = "=2.0.0-rc2" }
 
 # Deno dependencies - versions correspond to Deno v2.9.6
 deno_runtime = "0.266.0"

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,4 +1,4 @@
-# Devlopment
+# Development
 The vl-convert project consists of both Rust and Python components. The project uses [Pixi](https://pixi.sh/latest/) to manage the development environment. Pixi handles the installation of all the development dependencies including Python and Rust themselves. If you don't have Pixi installed, follow the instructions at https://pixi.sh/
 
 # Running Rust tests
@@ -23,7 +23,7 @@ pixi run test-py
 
 # Debug Logging
 To enable logging, set the RUST_LOG environment variable to info, warn, or error
-```
+```sh
 RUST_LOG=info
 ```
 
@@ -33,8 +33,6 @@ vl-convert uses the `cargo bundle-licenses` to bundle the licenses of its Rust d
 ```bash
 pixi run bundle-licenses
 ```
-
-If the generated license files are out of date, 
 
 # Build wheels
 
@@ -47,9 +45,10 @@ pixi run build-py
 # Linux Wheel Builds and V8
 
 Linux Python wheels link V8 into a shared library and therefore require a
-position-independent V8 archive. The upstream `rusty_v8` release archives now
-support this use case by enabling `v8_monolithic_for_shared_library`; see
-[denoland/rusty_v8#2008](https://github.com/denoland/rusty_v8/pull/2008).
+position-independent V8 archive. The upstream `rusty_v8` release archives
+support this use case by enabling `v8_monolithic_for_shared_library`. See
+[denoland/rusty_v8#2008](https://github.com/denoland/rusty_v8/pull/2008) for the
+implementation.
 
 CI and release builds use the archive downloaded by the `v8` crate. No custom
 V8 source build or vl-convert-hosted archive is required. The original linker
@@ -67,28 +66,91 @@ pixi run vendor
 For more information on the vendoring process, see [vl-convert-vendor/README.md](vl-convert-vendor/README.md). 
 
 # Release process
-Releases of VlConvert crates are handled using [cargo-workspaces](https://github.com/pksunkara/cargo-workspaces), which can be installed with:
 
-```bash
-pixi shell
-cargo install cargo-workspaces
+## Versions
+
+The Rust crates and `vl-convert-python` use one release version. The private `vl-convert-vendor` crate stays at `0.0.0`.
+
+## One-time repository setup
+
+The release workflow expects a GitHub environment named `release`. Configure
+the environment with the required reviewer and restrict it to tags that match
+`v*`. Add a `v*` tag ruleset that prevents unauthorized tag updates and
+deletions.
+
+Configure PyPI trusted publishing for the `vl-convert-python` project. Use the
+`vega/vl-convert` repository, `.github/workflows/Release.yml` workflow, and
+`release` environment.
+
+Configure the same workflow and environment as the
+trusted publisher for `vl-convert`, `vl-convert-canvas2d`,
+`vl-convert-canvas2d-deno`, `vl-convert-google-fonts`, `vl-convert-rs`, and
+`vl-convert-server` on crates.io.
+
+## Prepare the release pull request
+
+Define `<NEXT_VERSION>` as the next unused Rust SemVer without the `v` prefix.
+For example, use `2.0.0-rc3` for a release candidate.
+
+Run the dry run from a clean worktree:
+
+```sh
+pixi run prepare-release <NEXT_VERSION> -- --dry-run
 ```
 
-## Tagging and publish to crates.io
-Check out the main branch, then tag and publish new versions of the `vl-convert-canvas2d`, `vl-convert-canvas2d-deno`, `vl-convert-rs`, and `vl-convert` crates with:
+The dry run validates the workspace, version, Git remote, and release branch
+and tag names. It does not change local or remote state.
 
-(replacing `0.1.0` with the desired version)
+Create the release branch and draft pull request:
 
-```bash
-pixi shell
-cargo ws publish --all --force "vl-convert*" --allow-branch main custom 0.1.0
+```sh
+pixi run prepare-release <NEXT_VERSION>
 ```
 
-This command bumps all crate versions, updates inter-crate dependency versions, commits, tags (`v0.1.0`), and pushes to `origin/main`.
+The command creates `release/v<NEXT_VERSION>` from the latest `origin/main`,
+updates `Cargo.toml` and `Cargo.lock`, commits the version change, pushes the
+branch, and opens a draft pull request. Review the version and exact internal
+crate requirements before you mark the pull request ready. Merge the pull
+request only after its required checks pass. Then wait for the merged commit's
+checks on `main` to pass.
 
-## Publish Python packages to PyPI
-The push to `main` will trigger CI, including the "Publish to PyPI" job. This job must be approved manually in the GitHub interface. After it is approved it will run and publish the Python packages to PyPI.
+## Publish the GitHub Release
 
-## Create GitHub Release
-Create a new GitHub release using the `v0.1.0` tag.
+Create a GitHub Release with a new `v<NEXT_VERSION>` tag. Target the merged
+version commit on `main`. Write the release title and notes in the GitHub
+interface. Select **Set as a pre-release** when `<NEXT_VERSION>` has a
+prerelease component such as `-rc3`.
 
+WARNING: Publishing the GitHub Release starts irreversible uploads to crates.io
+and PyPI. The GitHub Release is visible before those uploads finish. After any
+registry upload starts, do not move, delete, or reuse the tag. Use a new release
+candidate or patch version for a source or workflow correction.
+
+Publish the GitHub Release to start the `Release` workflow. The workflow builds
+and verifies all native artifacts before the protected `release` environment
+permits registry publication. It then publishes six Rust crates and the Python
+distributions, uploads the artifacts to the existing GitHub Release, and
+verifies all three destinations. It does not change the Release title or notes.
+If validation rejects the prerelease setting, correct the GitHub Release and
+rerun the failed workflow before you approve registry publication.
+
+The GitHub Release must contain these assets:
+
+- Five CLI ZIP archives for Linux x86_64, Linux ARM64, Windows x86_64, macOS
+  x86_64, and macOS ARM64.
+- Five Python wheels for the same platforms.
+- One Python source distribution.
+- `SHA256SUMS` for the eleven package artifacts.
+
+Verify the published versions on [crates.io](https://crates.io/crates/vl-convert),
+[PyPI](https://pypi.org/project/vl-convert-python/), and the GitHub Release.
+
+If a transient publication or upload step fails, use **Re-run failed jobs** on
+the same workflow run and immutable tag. A rerun skips exact crate versions and
+Python files that the failed attempt already published. Prepare a new version
+when the source or workflow must change.
+
+Use the manual `workflow_dispatch` trigger to test release builds without
+publishing. The `linux_wheels_only` input limits that build-only run to the two
+Linux wheel jobs. The x86_64 job also builds the source distribution. Manual
+runs never publish packages or change a GitHub Release.

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -84,7 +84,7 @@ The command creates and pushes `release/v<NEXT_VERSION>` from the latest `origin
 
 Create and publish a GitHub Release with a new `v<NEXT_VERSION>` tag that targets the merged version commit on `main`. Mark the GitHub Release as a prerelease when the version has a prerelease component such as `-rc3`.
 
-Publishing the GitHub Release starts the `Release` workflow. The workflow builds and verifies the artifacts before it requests approval through the protected `release` environment. It then publishes the Rust crates and Python distributions, attaches the CLI archives, wheels, source distribution, and checksums, and verifies the registries and assets.
+Publishing the GitHub Release starts the `Release` workflow. The workflow builds and verifies the artifacts before it requests approval through the protected `release` environment. It then publishes the Rust crates and Python distributions and attaches the CLI archives, wheels, source distribution, and checksums.
 
 WARNING: Registry uploads are irreversible. After an upload starts, do not move, delete, or reuse the tag. Prepare a new version when the source or workflow must change.
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -44,16 +44,9 @@ pixi run build-py
 
 # Linux Wheel Builds and V8
 
-Linux Python wheels link V8 into a shared library and therefore require a
-position-independent V8 archive. The upstream `rusty_v8` release archives
-support this use case by enabling `v8_monolithic_for_shared_library`. See
-[denoland/rusty_v8#2008](https://github.com/denoland/rusty_v8/pull/2008) for the
-implementation.
+Linux Python wheels link V8 into a shared library and therefore require a position-independent V8 archive. The upstream `rusty_v8` release archives support this use case by enabling `v8_monolithic_for_shared_library`. See [denoland/rusty_v8#2008](https://github.com/denoland/rusty_v8/pull/2008) for the implementation.
 
-CI and release builds use the archive downloaded by the `v8` crate. No custom
-V8 source build or vl-convert-hosted archive is required. The original linker
-problem is documented in
-[denoland/rusty_v8#1706](https://github.com/denoland/rusty_v8/issues/1706).
+CI and release builds use the archive downloaded by the `v8` crate. No custom V8 source build or vl-convert-hosted archive is required. The original linker problem is documented in [denoland/rusty_v8#1706](https://github.com/denoland/rusty_v8/issues/1706).
 
 # Vendor JavaScript Dependencies
 vl-convert embeds vendored copies of all the JavaScript libraries it uses. The `vendor` Pixi task performs this 
@@ -73,24 +66,15 @@ The Rust crates and `vl-convert-python` use one release version. The private `vl
 
 ## One-time repository setup
 
-The release workflow expects a GitHub environment named `release`. Configure
-the environment with the required reviewer and restrict it to tags that match
-`v*`. Add a `v*` tag ruleset that prevents unauthorized tag updates and
-deletions.
+The release workflow expects a GitHub environment named `release`. Configure the environment with the required reviewer and restrict it to tags that match `v*`. Add a `v*` tag ruleset that prevents unauthorized tag updates and deletions.
 
-Configure PyPI trusted publishing for the `vl-convert-python` project. Use the
-`vega/vl-convert` repository, `.github/workflows/Release.yml` workflow, and
-`release` environment.
+Configure PyPI trusted publishing for the `vl-convert-python` project. Use the `vega/vl-convert` repository, `.github/workflows/Release.yml` workflow, and `release` environment.
 
-Configure the same workflow and environment as the
-trusted publisher for `vl-convert`, `vl-convert-canvas2d`,
-`vl-convert-canvas2d-deno`, `vl-convert-google-fonts`, `vl-convert-rs`, and
-`vl-convert-server` on crates.io.
+Configure the same workflow and environment as the trusted publisher for `vl-convert`, `vl-convert-canvas2d`, `vl-convert-canvas2d-deno`, `vl-convert-google-fonts`, `vl-convert-rs`, and `vl-convert-server` on crates.io.
 
 ## Prepare the release pull request
 
-Define `<NEXT_VERSION>` as the next unused Rust SemVer without the `v` prefix.
-For example, use `2.0.0-rc3` for a release candidate.
+Define `<NEXT_VERSION>` as the next unused Rust SemVer without the `v` prefix. For example, use `2.0.0-rc3` for a release candidate.
 
 Run the dry run from a clean worktree:
 
@@ -98,8 +82,7 @@ Run the dry run from a clean worktree:
 pixi run prepare-release <NEXT_VERSION> -- --dry-run
 ```
 
-The dry run validates the workspace, version, Git remote, and release branch
-and tag names. It does not change local or remote state.
+The dry run validates the workspace, version, Git remote, and release branch and tag names. It does not change local or remote state.
 
 Create the release branch and draft pull request:
 
@@ -107,50 +90,25 @@ Create the release branch and draft pull request:
 pixi run prepare-release <NEXT_VERSION>
 ```
 
-The command creates `release/v<NEXT_VERSION>` from the latest `origin/main`,
-updates `Cargo.toml` and `Cargo.lock`, commits the version change, pushes the
-branch, and opens a draft pull request. Review the version and exact internal
-crate requirements before you mark the pull request ready. Merge the pull
-request only after its required checks pass. Then wait for the merged commit's
-checks on `main` to pass.
+The command creates `release/v<NEXT_VERSION>` from the latest `origin/main`, updates `Cargo.toml` and `Cargo.lock`, commits the version change, pushes the branch, and opens a draft pull request. Review the version and exact internal crate requirements before you mark the pull request ready. Merge the pull request only after its required checks pass. Then wait for the merged commit's checks on `main` to pass.
 
 ## Publish the GitHub Release
 
-Create a GitHub Release with a new `v<NEXT_VERSION>` tag. Target the merged
-version commit on `main`. Write the release title and notes in the GitHub
-interface. Select **Set as a pre-release** when `<NEXT_VERSION>` has a
-prerelease component such as `-rc3`.
+Create a GitHub Release with a new `v<NEXT_VERSION>` tag. Target the merged version commit on `main`. Write the release title and notes in the GitHub interface. Select **Set as a pre-release** when `<NEXT_VERSION>` has a prerelease component such as `-rc3`.
 
-WARNING: Publishing the GitHub Release starts irreversible uploads to crates.io
-and PyPI. The GitHub Release is visible before those uploads finish. After any
-registry upload starts, do not move, delete, or reuse the tag. Use a new release
-candidate or patch version for a source or workflow correction.
+WARNING: Publishing the GitHub Release starts irreversible uploads to crates.io and PyPI. The GitHub Release is visible before those uploads finish. After any registry upload starts, do not move, delete, or reuse the tag. Use a new release candidate or patch version for a source or workflow correction.
 
-Publish the GitHub Release to start the `Release` workflow. The workflow builds
-and verifies all native artifacts before the protected `release` environment
-permits registry publication. It then publishes six Rust crates and the Python
-distributions, uploads the artifacts to the existing GitHub Release, and
-verifies all three destinations. It does not change the Release title or notes.
-If validation rejects the prerelease setting, correct the GitHub Release and
-rerun the failed workflow before you approve registry publication.
+Publish the GitHub Release to start the `Release` workflow. The workflow builds and verifies all native artifacts before the protected `release` environment permits registry publication. It then publishes six Rust crates and the Python distributions, uploads the artifacts to the existing GitHub Release, and verifies all three destinations. It does not change the Release title or notes. If validation rejects the prerelease setting, correct the GitHub Release and rerun the failed workflow before you approve registry publication.
 
 The GitHub Release must contain these assets:
 
-- Five CLI ZIP archives for Linux x86_64, Linux ARM64, Windows x86_64, macOS
-  x86_64, and macOS ARM64.
+- Five CLI ZIP archives for Linux x86_64, Linux ARM64, Windows x86_64, macOS x86_64, and macOS ARM64.
 - Five Python wheels for the same platforms.
 - One Python source distribution.
 - `SHA256SUMS` for the eleven package artifacts.
 
-Verify the published versions on [crates.io](https://crates.io/crates/vl-convert),
-[PyPI](https://pypi.org/project/vl-convert-python/), and the GitHub Release.
+Verify the published versions on [crates.io](https://crates.io/crates/vl-convert), [PyPI](https://pypi.org/project/vl-convert-python/), and the GitHub Release.
 
-If a transient publication or upload step fails, use **Re-run failed jobs** on
-the same workflow run and immutable tag. A rerun skips exact crate versions and
-Python files that the failed attempt already published. Prepare a new version
-when the source or workflow must change.
+If a transient publication or upload step fails, use **Re-run failed jobs** on the same workflow run and immutable tag. A rerun skips exact crate versions and Python files that the failed attempt already published. Prepare a new version when the source or workflow must change.
 
-Use the manual `workflow_dispatch` trigger to test release builds without
-publishing. The `linux_wheels_only` input limits that build-only run to the two
-Linux wheel jobs. The x86_64 job also builds the source distribution. Manual
-runs never publish packages or change a GitHub Release.
+Use the manual `workflow_dispatch` trigger to test release builds without publishing. The `linux_wheels_only` input limits that build-only run to the two Linux wheel jobs. The x86_64 job also builds the source distribution. Manual runs never publish packages or change a GitHub Release.

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -62,27 +62,15 @@ For more information on the vendoring process, see [vl-convert-vendor/README.md]
 
 ## Versions
 
-The Rust crates and `vl-convert-python` use one release version. The private `vl-convert-vendor` crate stays at `0.0.0`.
+The Rust crates and `vl-convert-python` share one version. The private `vl-convert-vendor` crate remains at `0.0.0`.
 
-## One-time repository setup
+## Prepare a release
 
-The release workflow expects a GitHub environment named `release`. Configure the environment with the required reviewer and restrict it to tags that match `v*`. Add a `v*` tag ruleset that prevents unauthorized tag updates and deletions.
-
-Configure PyPI trusted publishing for the `vl-convert-python` project. Use the `vega/vl-convert` repository, `.github/workflows/Release.yml` workflow, and `release` environment.
-
-Configure the same workflow and environment as the trusted publisher for `vl-convert`, `vl-convert-canvas2d`, `vl-convert-canvas2d-deno`, `vl-convert-google-fonts`, `vl-convert-rs`, and `vl-convert-server` on crates.io.
-
-## Prepare the release pull request
-
-Define `<NEXT_VERSION>` as the next unused Rust SemVer without the `v` prefix. For example, use `2.0.0-rc3` for a release candidate.
-
-Run the dry run from a clean worktree:
+Choose the next unused Rust SemVer without the `v` prefix. From a clean worktree, optionally validate the release inputs without changing local or remote state:
 
 ```sh
 pixi run prepare-release <NEXT_VERSION> -- --dry-run
 ```
-
-The dry run validates the workspace, version, Git remote, and release branch and tag names. It does not change local or remote state.
 
 Create the release branch and draft pull request:
 
@@ -90,25 +78,27 @@ Create the release branch and draft pull request:
 pixi run prepare-release <NEXT_VERSION>
 ```
 
-The command creates `release/v<NEXT_VERSION>` from the latest `origin/main`, updates `Cargo.toml` and `Cargo.lock`, commits the version change, pushes the branch, and opens a draft pull request. Review the version and exact internal crate requirements before you mark the pull request ready. Merge the pull request only after its required checks pass. Then wait for the merged commit's checks on `main` to pass.
+The command creates and pushes `release/v<NEXT_VERSION>` from the latest `origin/main`, updates the workspace version and exact internal requirements, refreshes the lockfile, and opens a draft pull request. Merge the pull request after its checks pass, then wait for the merged commit's checks on `main` to pass.
 
-## Publish the GitHub Release
+## Publish a release
 
-Create a GitHub Release with a new `v<NEXT_VERSION>` tag. Target the merged version commit on `main`. Write the release title and notes in the GitHub interface. Select **Set as a pre-release** when `<NEXT_VERSION>` has a prerelease component such as `-rc3`.
+Create and publish a GitHub Release with a new `v<NEXT_VERSION>` tag that targets the merged version commit on `main`. Mark the GitHub Release as a prerelease when the version has a prerelease component such as `-rc3`.
 
-WARNING: Publishing the GitHub Release starts irreversible uploads to crates.io and PyPI. The GitHub Release is visible before those uploads finish. After any registry upload starts, do not move, delete, or reuse the tag. Use a new release candidate or patch version for a source or workflow correction.
+Publishing the GitHub Release starts the `Release` workflow. The workflow builds and verifies the artifacts before it requests approval through the protected `release` environment. It then publishes the Rust crates and Python distributions, attaches the CLI archives, wheels, source distribution, and checksums, and verifies the registries and assets.
 
-Publish the GitHub Release to start the `Release` workflow. The workflow builds and verifies all native artifacts before the protected `release` environment permits registry publication. It then publishes six Rust crates and the Python distributions, uploads the artifacts to the existing GitHub Release, and verifies all three destinations. It does not change the Release title or notes. If validation rejects the prerelease setting, correct the GitHub Release and rerun the failed workflow before you approve registry publication.
+WARNING: Registry uploads are irreversible. After an upload starts, do not move, delete, or reuse the tag. Prepare a new version when the source or workflow must change.
 
-The GitHub Release must contain these assets:
+## Retry or test the workflow
 
-- Five CLI ZIP archives for Linux x86_64, Linux ARM64, Windows x86_64, macOS x86_64, and macOS ARM64.
-- Five Python wheels for the same platforms.
-- One Python source distribution.
-- `SHA256SUMS` for the eleven package artifacts.
+For a transient failure, rerun the failed jobs on the same workflow run. The retry skips exact crate versions and Python files that are already published.
 
-Verify the published versions on [crates.io](https://crates.io/crates/vl-convert), [PyPI](https://pypi.org/project/vl-convert-python/), and the GitHub Release.
+Use the manual `workflow_dispatch` trigger to test builds without publishing. The `linux_wheels_only` input limits the run to the two Linux wheel jobs.
 
-If a transient publication or upload step fails, use **Re-run failed jobs** on the same workflow run and immutable tag. A rerun skips exact crate versions and Python files that the failed attempt already published. Prepare a new version when the source or workflow must change.
+## One-time repository setup
 
-Use the manual `workflow_dispatch` trigger to test release builds without publishing. The `linux_wheels_only` input limits that build-only run to the two Linux wheel jobs. The x86_64 job also builds the source distribution. Manual runs never publish packages or change a GitHub Release.
+Configure a GitHub environment named `release` with a required reviewer and restrict it to `v*` tags. Add a `v*` tag ruleset that prevents unauthorized updates and deletions.
+
+Configure trusted publishing with the `vega/vl-convert` repository, `.github/workflows/Release.yml` workflow, and `release` environment for:
+
+- The `vl-convert-python` project on PyPI.
+- The `vl-convert`, `vl-convert-canvas2d`, `vl-convert-canvas2d-deno`, `vl-convert-google-fonts`, `vl-convert-rs`, and `vl-convert-server` crates on crates.io.

--- a/pixi.lock
+++ b/pixi.lock
@@ -59,6 +59,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.4-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.100.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
@@ -221,6 +222,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py311hd632256_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he1f765f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py311h8a92878_2.conda
@@ -236,6 +238,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
@@ -319,6 +322,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.4-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gh-2.100.0-h5839d16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
@@ -471,6 +475,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.95.0-h38e4360_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py311h3c3ac6d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.15.2-py311h0c91ca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.1.2-py311hda9c9d0_2.conda
@@ -485,6 +490,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
@@ -578,6 +584,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.4-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.100.0-hf76c51c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.86.0-h52a91e1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.86.0-hb9d6e3a_0.conda
@@ -741,6 +748,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.95.0-hf6ec828_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.1-py311hbfb48bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311h2929bc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.1.2-py311hd4fb369_2.conda
@@ -755,6 +763,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
@@ -869,6 +878,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.4-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.100.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
@@ -1037,6 +1047,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py311hdcb8d17_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hd4686c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.7-py311hd54bd37_0.conda
@@ -1054,6 +1065,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
@@ -2986,6 +2998,39 @@ packages:
   purls: []
   size: 123087
   timestamp: 1726603487099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.100.0-hfc2019e_0.conda
+  sha256: 2a056103b78abe5c573026e6cd7ccc1b86ecab0b86095e91ad6a2d1b0694ec38
+  md5: fddd60225199c33914ded964f1507727
+  license: Apache-2.0
+  purls: []
+  size: 13958307
+  timestamp: 1788786016022
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gh-2.100.0-h5839d16_0.conda
+  sha256: be6d3c8c9b43decf63f795a1222cc55054d56f46b6164e5e31e8de4e45b1a018
+  md5: b67f52bb6d06b8049730049e41748577
+  constrains:
+  - __osx >=10.12
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 13853434
+  timestamp: 1788475666154
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.100.0-hf76c51c_0.conda
+  sha256: 557955ed3aa15fddd55382f0d9357c675a5b91c3c1450b947c7d57997f841bf5
+  md5: 1cfdf2468abf2a43b4ea28d364541a96
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 12536766
+  timestamp: 1788475533591
+- conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.100.0-h11686cb_0.conda
+  sha256: 62f01e78a5b95a15f785edc53e1eceae2b5202a6d4765bb4c928617585897f7b
+  md5: 1c95475bef3c6faefe89bcdf35793134
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 13396026
+  timestamp: 1788475519800
 - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   md5: 3bf7b9fd5a7136126e0234db4b87c8b6
@@ -9673,6 +9718,18 @@ packages:
   - pkg:pypi/scipy?source=hash-mapping
   size: 16267830
   timestamp: 1724329250657
+- conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
+  sha256: bea67173ed67c73cf16691ef72e58059492ac1ed1c880cfbeb6f1295c5add7d6
+  md5: 8e7be844ccb9706a999a337e056606ab
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/semver?source=hash-mapping
+  size: 22532
+  timestamp: 1767294175877
 - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
   sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
   md5: 778594b20097b5a948c59e50ae42482a
@@ -10114,6 +10171,18 @@ packages:
   - pkg:pypi/tomli?source=hash-mapping
   size: 15940
   timestamp: 1644342331069
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.1-pyhcf101f3_0.conda
+  sha256: 5cf833b4d199688b7652fb322ecc134de9555e9444d9249750de9a153421ad0a
+  md5: e4942e2de7436ff28be7f5645cf3c8d6
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomlkit?source=hash-mapping
+  size: 49054
+  timestamp: 1784287707171
 - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
   sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
   md5: 2fcb582444635e2c402e8569bb94e039

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,10 @@ cp thirdparty_*.* vl-convert-python/ &&
 cp thirdparty_*.* vl-convert-rs/ &&
 cp thirdparty_*.* vl-convert/
 """
+prepare-release = { cmd = ["python", "scripts/release.py", "{{ version }}"], args = ["version"] }
+check-workspace = { cmd = ["python", "scripts/check_workspace.py"] }
+fmt-release-check = { cmd = ["ruff", "format", "scripts", "--check"] }
+lint-release = { cmd = ["ruff", "check", "scripts", "--select", "E,F,I,UP"] }
 
 [pypi-dependencies]
 playwright = ">=1.40"
@@ -50,6 +54,10 @@ playwright = ">=1.40"
 python = "3.11.*"
 maturin = "1.8.*"
 rust = "1.95.*"
+gh = ">=2.80,<3"
+packaging = ">=23,<26"
+semver = ">=3,<4"
+tomlkit = ">=0.13,<1"
 protobuf = ">=4.25.3,<5"
 ruff = ">=0.8,<1"
 pip = ">=24.2,<25"

--- a/scripts/assemble_release_artifacts.py
+++ b/scripts/assemble_release_artifacts.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Verify and assemble release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+from collections import Counter
+from pathlib import Path
+
+
+def expected_artifacts(version: str) -> set[str]:
+    return {
+        "vl-convert_linux-64.zip",
+        "vl-convert_linux-aarch64.zip",
+        "vl-convert_osx-64.zip",
+        "vl-convert_osx-arm64.zip",
+        "vl-convert_win-64.zip",
+        f"vl_convert_python-{version}-cp39-abi3-macosx_10_12_x86_64.whl",
+        f"vl_convert_python-{version}-cp39-abi3-macosx_11_0_arm64.whl",
+        f"vl_convert_python-{version}-cp39-abi3-manylinux_2_28_aarch64.whl",
+        f"vl_convert_python-{version}-cp39-abi3-manylinux_2_28_x86_64.whl",
+        f"vl_convert_python-{version}-cp39-abi3-win_amd64.whl",
+        f"vl_convert_python-{version}.tar.gz",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    parser.add_argument("incoming", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    expected = expected_artifacts(args.version)
+    files = [path for path in args.incoming.rglob("*") if path.is_file()]
+    actual = Counter(path.name for path in files)
+    wanted = Counter(expected)
+    if actual != wanted:
+        missing = sorted((wanted - actual).elements())
+        extra = sorted((actual - wanted).elements())
+        raise SystemExit(f"Artifact mismatch; missing={missing}, extra={extra}")
+
+    args.output.mkdir()
+    for path in files:
+        shutil.copy2(path, args.output / path.name)
+
+    with (args.output / "SHA256SUMS").open("w", encoding="utf-8") as checksums:
+        for name in sorted(expected):
+            digest = hashlib.sha256((args.output / name).read_bytes()).hexdigest()
+            checksums.write(f"{digest}  {name}\n")
+
+    print(f"Assembled {len(expected)} artifacts in {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_workspace.py
+++ b/scripts/check_workspace.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Check the workspace metadata used by the release process."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_MANIFEST = ROOT / "Cargo.toml"
+PYTHON_PACKAGE = "vl-convert-python"
+VENDOR_PACKAGE = "vl-convert-vendor"
+PRODUCT_PACKAGES = (
+    "vl-convert",
+    "vl-convert-canvas2d",
+    "vl-convert-canvas2d-deno",
+    "vl-convert-google-fonts",
+    PYTHON_PACKAGE,
+    "vl-convert-rs",
+    "vl-convert-server",
+)
+INTERNAL_DEPENDENCIES = (
+    "vl-convert-canvas2d",
+    "vl-convert-canvas2d-deno",
+    "vl-convert-google-fonts",
+    "vl-convert-rs",
+    "vl-convert-server",
+)
+PUBLISHABLE_PACKAGES = tuple(p for p in PRODUCT_PACKAGES if p != PYTHON_PACKAGE)
+
+
+class WorkspaceError(RuntimeError):
+    pass
+
+
+def python_version(version: str) -> str:
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        return str(Version(version))
+    except InvalidVersion as error:
+        raise WorkspaceError(f"Version {version} is not valid for Python") from error
+
+
+def validate_workspace() -> str:
+    result = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--locked",
+            "--no-deps",
+            "--format-version",
+            "1",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata = json.loads(result.stdout)
+    manifest = tomllib.loads(ROOT_MANIFEST.read_text(encoding="utf-8"))
+    packages = {package["name"]: package for package in metadata["packages"]}
+    version = manifest["workspace"]["package"]["version"]
+    if "+" in version:
+        raise WorkspaceError("Release versions cannot contain build metadata")
+
+    required = set(PRODUCT_PACKAGES) | {VENDOR_PACKAGE}
+    if set(packages) != required:
+        raise WorkspaceError(
+            f"Expected workspace packages {sorted(required)}, found {sorted(packages)}"
+        )
+
+    mismatches = {
+        name: packages[name]["version"]
+        for name in PRODUCT_PACKAGES
+        if packages[name]["version"] != version
+    }
+    if mismatches:
+        details = ", ".join(f"{name}={value}" for name, value in mismatches.items())
+        raise WorkspaceError(f"Product versions do not match {version}: {details}")
+
+    vendor = packages[VENDOR_PACKAGE]
+    if vendor["version"] != "0.0.0" or vendor.get("publish") != []:
+        raise WorkspaceError(f"{VENDOR_PACKAGE} must be private at version 0.0.0")
+    if packages[PYTHON_PACKAGE].get("publish") != []:
+        raise WorkspaceError(f"{PYTHON_PACKAGE} must remain private on crates.io")
+    for name in PUBLISHABLE_PACKAGES:
+        if packages[name].get("publish") == []:
+            raise WorkspaceError(f"{name} must remain publishable")
+
+    workspace_dependencies = manifest["workspace"]["dependencies"]
+    expected_requirement = f"={version}"
+    for name in INTERNAL_DEPENDENCIES:
+        dependency = workspace_dependencies.get(name)
+        if not isinstance(dependency, dict):
+            raise WorkspaceError(f"Missing workspace dependency {name}")
+        if dependency.get("version") != expected_requirement:
+            raise WorkspaceError(
+                f"Workspace dependency {name} must require {expected_requirement}"
+            )
+
+    for package in packages.values():
+        for dependency in package.get("dependencies", []):
+            if (
+                dependency["name"] in INTERNAL_DEPENDENCIES
+                and dependency["req"] != expected_requirement
+            ):
+                raise WorkspaceError(
+                    f"{package['name']} requires {dependency['name']} "
+                    f"{dependency['req']}; expected {expected_requirement}"
+                )
+
+    return version
+
+
+def main() -> int:
+    try:
+        version = validate_workspace()
+    except WorkspaceError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as error:
+        details = (error.stderr or error.stdout or str(error)).strip()
+        print(f"error: {details}", file=sys.stderr)
+        return error.returncode
+
+    print(f"Validated Rust version {version}")
+    print(f"Validated Python version {python_version(version)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -105,9 +105,13 @@ def update_root_manifest(version: str) -> None:
 def pull_request_body(current: str, version: str) -> str:
     release_kind = "prerelease" if "-" in version else "stable release"
     packages = "\n".join(f"- `{name}`" for name in PRODUCT_PACKAGES)
+    summary = (
+        f"Prepare `{version}` as a {release_kind}. This updates the shared workspace "
+        f"version and exact internal package requirements from `{current}`."
+    )
     return f"""## Summary
 
-Prepare `{version}` as a {release_kind}. This updates the shared workspace version and exact internal package requirements from `{current}`.
+{summary}
 
 ## Packages
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Create a release branch and draft pull request."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+
+from check_workspace import (
+    INTERNAL_DEPENDENCIES,
+    PRODUCT_PACKAGES,
+    ROOT,
+    ROOT_MANIFEST,
+    WorkspaceError,
+    python_version,
+    validate_workspace,
+)
+
+GITHUB_REPOSITORY = "vega/vl-convert"
+EXPECTED_RELEASE_CHANGES = {"Cargo.toml", "Cargo.lock"}
+
+
+def run(
+    args: Sequence[str], *, check: bool = True, capture: bool = True
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=ROOT,
+        check=check,
+        capture_output=capture,
+        text=True,
+    )
+
+
+def git(
+    *args: str, check: bool = True, capture: bool = True
+) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], check=check, capture=capture)
+
+
+def parse_new_version(value: str, current: str) -> str:
+    import semver
+
+    if value.startswith("v"):
+        raise WorkspaceError("Pass the version without the v tag prefix")
+    try:
+        version = semver.Version.parse(value)
+        current_version = semver.Version.parse(current)
+    except ValueError as error:
+        raise WorkspaceError(f"Invalid Rust SemVer: {error}") from error
+    if version.build is not None:
+        raise WorkspaceError("Release versions cannot contain build metadata")
+    if version <= current_version:
+        raise WorkspaceError(f"Version {version} must be newer than {current}")
+    python_version(str(version))
+    return str(version)
+
+
+def ensure_clean_worktree() -> None:
+    status = git("status", "--porcelain", "--untracked-files=all").stdout.strip()
+    if status:
+        raise WorkspaceError(f"The worktree is not clean:\n{status}")
+
+
+def ensure_canonical_origin() -> None:
+    origin = git("remote", "get-url", "origin").stdout.strip().removesuffix(".git")
+    if not origin.endswith(
+        ("github.com/vega/vl-convert", "github.com:vega/vl-convert")
+    ):
+        raise WorkspaceError(
+            f"origin must identify {GITHUB_REPOSITORY}, found {origin}"
+        )
+
+
+def ref_exists(ref: str) -> bool:
+    return git(
+        "show-ref", "--verify", "--quiet", ref, check=False
+    ).returncode == 0 or bool(git("ls-remote", "origin", ref).stdout.strip())
+
+
+def ensure_release_name_available(version: str) -> None:
+    branch = f"release/v{version}"
+    tag = f"v{version}"
+    for ref, label in (
+        (f"refs/heads/{branch}", f"branch {branch}"),
+        (f"refs/tags/{tag}", f"tag {tag}"),
+    ):
+        if ref_exists(ref):
+            raise WorkspaceError(f"Release {label} already exists")
+
+
+def update_root_manifest(version: str) -> None:
+    import tomlkit
+
+    document = tomlkit.parse(ROOT_MANIFEST.read_text(encoding="utf-8"))
+    document["workspace"]["package"]["version"] = version
+    dependencies = document["workspace"]["dependencies"]
+    for name in INTERNAL_DEPENDENCIES:
+        dependencies[name]["version"] = f"={version}"
+    ROOT_MANIFEST.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+
+def pull_request_body(current: str, version: str) -> str:
+    release_kind = "prerelease" if "-" in version else "stable release"
+    packages = "\n".join(f"- `{name}`" for name in PRODUCT_PACKAGES)
+    return f"""## Summary
+
+Prepare `{version}` as a {release_kind}. This updates the shared workspace version
+and exact internal package requirements from `{current}`.
+
+## Packages
+
+{packages}
+
+## After merge
+
+- Wait for all required CI checks on `main`.
+- Create a GitHub Release with a new `v{version}` tag that targets `main`.
+- Mark it as a prerelease when the version contains a prerelease component.
+- Publish the GitHub Release to start package and artifact publishing.
+"""
+
+
+def prepare_release(value: str, *, dry_run: bool) -> None:
+    current = validate_workspace()
+    version = parse_new_version(value, current)
+    branch = f"release/v{version}"
+    tag = f"v{version}"
+
+    ensure_clean_worktree()
+    ensure_canonical_origin()
+    run(["gh", "auth", "status", "--hostname", "github.com"])
+    ensure_release_name_available(version)
+
+    if dry_run:
+        remote_main = git("ls-remote", "origin", "refs/heads/main").stdout.split()
+        if not remote_main:
+            raise WorkspaceError("origin/main does not exist")
+        base = remote_main[0]
+    else:
+        git("fetch", "origin", "main", capture=False)
+        base = git("rev-parse", "origin/main").stdout.strip()
+
+    print(f"Current version: {current}")
+    print(f"New version: {version}")
+    print(f"Python version: {python_version(version)}")
+    print(f"Base: origin/main at {base}")
+    print(f"Branch: {branch}")
+    print("Files: Cargo.toml, Cargo.lock")
+    print(f"Commit: chore: prepare {tag}")
+    print(f"Pull request: draft against {GITHUB_REPOSITORY}:main")
+    if dry_run:
+        print("Dry run complete. No local or remote state changed.")
+        return
+
+    git("switch", "--create", branch, "origin/main", capture=False)
+    update_root_manifest(version)
+    run(["cargo", "update", "--workspace"], capture=False)
+    validate_workspace()
+
+    changed = set(git("diff", "--name-only").stdout.splitlines())
+    if changed != EXPECTED_RELEASE_CHANGES:
+        raise WorkspaceError(
+            f"Expected changes to {sorted(EXPECTED_RELEASE_CHANGES)}, "
+            f"found {sorted(changed)}"
+        )
+    git("diff", "--check")
+    git("add", *sorted(EXPECTED_RELEASE_CHANGES), capture=False)
+    git("commit", "-m", f"chore: prepare {tag}", capture=False)
+    git("push", "--set-upstream", "origin", branch, capture=False)
+    run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            GITHUB_REPOSITORY,
+            "--base",
+            "main",
+            "--head",
+            branch,
+            "--draft",
+            "--title",
+            f"chore: prepare {tag}",
+            "--body",
+            pull_request_body(current, version),
+        ],
+        capture=False,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        prepare_release(args.version, dry_run=args.dry_run)
+    except WorkspaceError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as error:
+        details = (error.stderr or error.stdout or str(error)).strip()
+        print(f"error: {details}", file=sys.stderr)
+        return error.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -107,8 +107,7 @@ def pull_request_body(current: str, version: str) -> str:
     packages = "\n".join(f"- `{name}`" for name in PRODUCT_PACKAGES)
     return f"""## Summary
 
-Prepare `{version}` as a {release_kind}. This updates the shared workspace version
-and exact internal package requirements from `{current}`.
+Prepare `{version}` as a {release_kind}. This updates the shared workspace version and exact internal package requirements from `{current}`.
 
 ## Packages
 

--- a/vl-convert-canvas2d-deno/Cargo.toml
+++ b/vl-convert-canvas2d-deno/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "vl-convert-canvas2d-deno"
-version = "2.0.0-rc2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Deno extension for Canvas 2D API wrapping vl-convert-canvas2d"
-license = "BSD-3-Clause"
-repository = "https://github.com/vega/vl-convert"
+license.workspace = true
+repository.workspace = true
 readme = "README.md"
 keywords = ["canvas", "2d", "deno", "graphics"]
 
@@ -18,7 +18,7 @@ deno_core = { workspace = true }
 deno_error = { workspace = true }
 
 # Canvas 2D implementation
-vl-convert-canvas2d = { path = "../vl-convert-canvas2d", version = "2.0.0-rc1" }
+vl-convert-canvas2d = { workspace = true }
 
 # For gradient color parsing
 csscolorparser = "0.8.4"

--- a/vl-convert-canvas2d/Cargo.toml
+++ b/vl-convert-canvas2d/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "vl-convert-canvas2d"
-version = "2.0.0-rc2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Pure Rust Canvas 2D API implementation using tiny-skia and cosmic-text"
-license = "BSD-3-Clause"
-repository = "https://github.com/vega/vl-convert"
+license.workspace = true
+repository.workspace = true
 readme = "README.md"
 keywords = ["canvas", "2d", "graphics", "tiny-skia"]
 

--- a/vl-convert-google-fonts/Cargo.toml
+++ b/vl-convert-google-fonts/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "vl-convert-google-fonts"
-version = "2.0.0-rc2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Google Fonts downloading and caching"
-license = "BSD-3-Clause"
+license.workspace = true
 readme = "README.md"
 homepage = "https://github.com/vega/vl-convert"
-repository = "https://github.com/vega/vl-convert"
+repository.workspace = true
 keywords = ["Fonts", "Google-Fonts"]
 
 [features]

--- a/vl-convert-python/Cargo.toml
+++ b/vl-convert-python/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "vl-convert-python"
-version = "2.0.0-rc2"
-edition = "2021"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 readme = "README.md"
 homepage = "https://github.com/jonmmease/vl-convert"
-repository = "https://github.com/jonmmease/vl-convert"
+repository.workspace = true
 publish = false
-
-[package.metadata.release]
-release = false
 
 [lib]
 name = "vl_convert"
 crate-type = ["cdylib"]
 
 [dependencies]
-vl-convert-rs = { path = "../vl-convert-rs", version = "2.0.0-rc1" }
+vl-convert-rs = { workspace = true }
 pyo3 = { workspace = true }
 lazy_static = { workspace = true }
 futures = { workspace = true }

--- a/vl-convert-rs/Cargo.toml
+++ b/vl-convert-rs/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vl-convert-rs"
-version = "2.0.0-rc2"
-edition = "2021"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 readme = "README.md"
 homepage = "https://github.com/jonmmease/vl-convert"
-repository = "https://github.com/jonmmease/vl-convert"
+repository.workspace = true
 description = "Library for converting Vega-Lite visualization specifications to Vega specifications"
 keywords = ["Visualization", "Vega", "Vega-Lite"]
 
@@ -17,9 +17,9 @@ rustc-args = ["--cfg", "vl_convert_docsrs"]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(vl_convert_docsrs)"] }
 
 [dependencies]
-vl-convert-canvas2d = { path = "../vl-convert-canvas2d", version = "2.0.0-rc1" }
-vl-convert-canvas2d-deno = { path = "../vl-convert-canvas2d-deno", version = "2.0.0-rc1", features = ["svg"] }
-vl-convert-google-fonts = { path = "../vl-convert-google-fonts", version = "2.0.0-rc1", features = ["fontdb"] }
+vl-convert-canvas2d = { workspace = true }
+vl-convert-canvas2d-deno = { workspace = true, features = ["svg"] }
+vl-convert-google-fonts = { workspace = true, features = ["fontdb"] }
 
 arc-swap = "1.9"
 deno_runtime = { workspace = true }
@@ -88,4 +88,4 @@ deno_error = { workspace = true }
 # Need "snapshot" feature to access deno_runtime::snapshot::create_runtime_snapshot
 deno_runtime = { workspace = true, features = ["snapshot"] }
 # Canvas 2D Deno extension - used in snapshot creation
-vl-convert-canvas2d-deno = { path = "../vl-convert-canvas2d-deno", version = "2.0.0-rc1" }
+vl-convert-canvas2d-deno = { workspace = true }

--- a/vl-convert-server/Cargo.toml
+++ b/vl-convert-server/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vl-convert-server"
-version = "2.0.0-rc2"
-edition = "2021"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 readme = "README.md"
 homepage = "https://github.com/jonmmease/vl-convert"
-repository = "https://github.com/jonmmease/vl-convert"
+repository.workspace = true
 description = "HTTP server for converting Vega-Lite and Vega specifications to static images"
 keywords = ["Visualization", "Vega", "Vega-Lite", "Server"]
 
@@ -14,8 +14,8 @@ keywords = ["Visualization", "Vega", "Vega-Lite", "Server"]
 rustc-args = ["--cfg", "vl_convert_docsrs"]
 
 [dependencies]
-vl-convert-rs = { path = "../vl-convert-rs", version = "2.0.0-rc1" }
-vl-convert-google-fonts = { path = "../vl-convert-google-fonts", version = "2.0.0-rc1" }
+vl-convert-rs = { workspace = true }
+vl-convert-google-fonts = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 serde = { workspace = true }

--- a/vl-convert-vendor/Cargo.toml
+++ b/vl-convert-vendor/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "vl-convert-vendor"
-version = "2.0.0-rc2"
-edition = "2021"
-license = "BSD-3-Clause"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
 readme = "README.md"
 homepage = "https://github.com/jonmmease/vl-convert"
-repository = "https://github.com/jonmmease/vl-convert"
+repository.workspace = true
 publish = false
-
-[package.metadata.release]
-release = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/vl-convert/Cargo.toml
+++ b/vl-convert/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "vl-convert"
-version = "2.0.0-rc2"
-edition = "2021"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 readme = "README.md"
 documentation = "https://github.com/vega/vl-convert/blob/main/vl-convert/README.md"
 homepage = "https://github.com/jonmmease/vl-convert"
-repository = "https://github.com/jonmmease/vl-convert"
+repository.workspace = true
 description = "CLI application for converting Vega-Lite visualization specifications to Vega specifications"
 keywords = ["Visualization", "Vega", "Vega-Lite"]
 
 [dependencies]
-vl-convert-rs = { path = "../vl-convert-rs", version = "2.0.0-rc1" }
-vl-convert-google-fonts = { path = "../vl-convert-google-fonts", version = "2.0.0-rc1" }
-vl-convert-server = { path = "../vl-convert-server", version = "2.0.0-rc1" }
+vl-convert-rs = { workspace = true }
+vl-convert-google-fonts = { workspace = true }
+vl-convert-server = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Reworks publication of rust crates and python packages to be done in a CI in response to a GitHub Release, which should be performed after a PR to bump the version.

This removes use of `cargo-workspaces` and will let us protect the main branch