### PR TITLE
ci: fix release task arguments and update actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - uses: prefix-dev/setup-pixi@v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           pixi-version: v0.47.0
       - name: Check cargo fmt compliance
@@ -36,7 +36,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2.9.2
         with:
           cache-on-failure: True
       - name: Install Protoc
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - uses: prefix-dev/setup-pixi@v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           pixi-version: v0.47.0
       - name: Check that license is up to date
@@ -74,7 +74,7 @@ jobs:
       - name: Install latest stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2.9.2
         with:
           prefix-key: "v1-rust"
           cache-on-failure: True
@@ -126,7 +126,7 @@ jobs:
       - name: Install latest stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2.9.2
         with:
           prefix-key: "v1-rust"
           cache-on-failure: True
@@ -158,11 +158,11 @@ jobs:
       - name: Install latest stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2.9.2
         with:
           prefix-key: "v1-rust"
           cache-on-failure: True
@@ -231,11 +231,11 @@ jobs:
         run: git config --system core.longpaths true
       - name: Check out repository code
         uses: actions/checkout@v7
-      - uses: prefix-dev/setup-pixi@v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           pixi-version: v0.47.0
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2.9.2
         with:
           prefix-key: "v1-rust"
           cache-on-failure: True

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Install Rust toolchain
@@ -391,7 +391,7 @@ jobs:
           ref: ${{ needs.validate.outputs.source_ref }}
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
       - name: Install Protoc
@@ -436,7 +436,7 @@ jobs:
           ref: ${{ needs.validate.outputs.source_ref }}
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
       - name: Install Protoc
@@ -478,7 +478,7 @@ jobs:
           ref: ${{ needs.validate.outputs.source_ref }}
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
       - name: Install Protoc

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -69,7 +69,7 @@ The Rust crates and `vl-convert-python` share one version. The private `vl-conve
 Choose the next unused Rust SemVer without the `v` prefix. From a clean worktree, optionally validate the release inputs without changing local or remote state:
 
 ```sh
-pixi run prepare-release <NEXT_VERSION> -- --dry-run
+pixi run prepare-release <NEXT_VERSION> --dry-run
 ```
 
 Create the release branch and draft pull request:

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,7 +41,7 @@ cp thirdparty_*.* vl-convert-python/ &&
 cp thirdparty_*.* vl-convert-rs/ &&
 cp thirdparty_*.* vl-convert/
 """
-prepare-release = { cmd = ["python", "scripts/release.py", "{{ version }}"], args = ["version"] }
+prepare-release = "python scripts/release.py"
 check-workspace = { cmd = ["python", "scripts/check_workspace.py"] }
 fmt-release-check = { cmd = ["ruff", "format", "scripts", "--check"] }
 lint-release = { cmd = ["ruff", "check", "scripts", "--select", "E,F,I,UP"] }


### PR DESCRIPTION
## Why
The `prepare-release` Pixi task was only accepting a version argument, so it rejected the `--dry-run` option before the release script receives it. 

Fixes the above, and updates three workflow actions that were behind their current releases.
