### PR TITLE
chore: prepare v2.0.0-rc5

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -316,7 +316,7 @@ jobs:
           manylinux: 2_28
           target: x86_64-unknown-linux-gnu
           command: build
-          args: --release --locked -m vl-convert-python/Cargo.toml --sdist -o dist --strip
+          args: --release -m vl-convert-python/Cargo.toml --sdist -o dist --strip
           before-script-linux: |
             dnf install -y glib2-devel libffi-devel clang-devel || yum install -y glib2-devel libffi-devel clang-devel
             PB_REL="https://github.com/protocolbuffers/protobuf/releases"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10853,7 +10853,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vl-convert"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "assert_cmd",
  "bytes",
@@ -10882,7 +10882,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-canvas2d"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "cosmic-text",
  "csscolorparser",
@@ -10901,7 +10901,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-canvas2d-deno"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "csscolorparser",
  "deno_core",
@@ -10917,7 +10917,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-google-fonts"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "backon",
  "dashmap 6.2.1",
@@ -10936,7 +10936,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-python"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "futures",
  "lazy_static",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-rs"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "arc-swap",
  "backon",
@@ -11004,7 +11004,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-server"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/vega/vl-convert"
@@ -32,11 +32,11 @@ backon = { version = "1", default-features = false, features = ["tokio-sleep", "
 clap = { version = "4.5", features = ["derive", "env"] }
 
 # Internal packages are released in lockstep.
-vl-convert-canvas2d = { path = "vl-convert-canvas2d", version = "=2.0.0-rc4" }
-vl-convert-canvas2d-deno = { path = "vl-convert-canvas2d-deno", version = "=2.0.0-rc4" }
-vl-convert-google-fonts = { path = "vl-convert-google-fonts", version = "=2.0.0-rc4" }
-vl-convert-rs = { path = "vl-convert-rs", version = "=2.0.0-rc4" }
-vl-convert-server = { path = "vl-convert-server", version = "=2.0.0-rc4" }
+vl-convert-canvas2d = { path = "vl-convert-canvas2d", version = "=2.0.0-rc5" }
+vl-convert-canvas2d-deno = { path = "vl-convert-canvas2d-deno", version = "=2.0.0-rc5" }
+vl-convert-google-fonts = { path = "vl-convert-google-fonts", version = "=2.0.0-rc5" }
+vl-convert-rs = { path = "vl-convert-rs", version = "=2.0.0-rc5" }
+vl-convert-server = { path = "vl-convert-server", version = "=2.0.0-rc5" }
 
 # Deno dependencies - versions correspond to Deno v2.9.6
 deno_runtime = "0.266.0"


### PR DESCRIPTION
## Why

Maturin 1.15 builds the Linux x86_64 wheel from the generated source distribution. For a Cargo workspace, Maturin removes unrelated members from the source distribution without reconciling `Cargo.lock`, so its internal `--locked` wheel build fails before compilation.

## What

Prepare the workspace packages for `2.0.0-rc5` and remove `--locked` only from the combined Linux x86_64 wheel and source distribution build. The other wheel builds and Rust package checks continue to enforce the checked-in lockfile.

## Related issues

- Related to PyO3/maturin#2609
- Related to PyO3/maturin#3192
