### PR TITLE
fix: restore Altair PDF export compatibility

### DIFF
--- a/vl-convert-python/src/conversions.rs
+++ b/vl-convert-python/src/conversions.rs
@@ -16,6 +16,17 @@ use vl_convert_rs::converter::{
 };
 use vl_convert_rs::module_loader::import_map::VlVersion;
 
+fn validate_pdf_scale(scale: Option<f64>) -> PyResult<()> {
+    if let Some(scale) = scale {
+        if scale != 1.0 {
+            return Err(PyValueError::new_err(
+                "The scale argument must be 1 for PDF output.",
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Convert a Vega-Lite spec to a Vega spec using a particular
 /// version of the Vega-Lite JavaScript library.
 ///
@@ -830,6 +841,11 @@ pub fn vegalite_to_jpeg(
 ///
 /// Args:
 ///     vg_spec (str | dict): Vega JSON specification string or dict
+///     scale (float):
+///         .. deprecated:: 2.0.0
+///            Retained only for backward compatibility with vl-convert 1.x.
+///            The parameter has no effect on PDF output. The only non-None
+///            value accepted is 1.0. Any other numeric value raises ValueError.
 ///     format_locale (str | dict): d3-format locale name or dictionary
 ///     time_format_locale (str | dict): d3-time-format locale name or dictionary
 ///     vega_plugin (str): Per-request Vega plugin (inline ESM string or URL)
@@ -844,6 +860,7 @@ pub fn vegalite_to_jpeg(
 #[pyo3(signature = (
     vg_spec,
     *,
+    scale=None,
     format_locale=None,
     time_format_locale=None,
     vega_plugin=None,
@@ -855,6 +872,7 @@ pub fn vegalite_to_jpeg(
 ))]
 pub fn vega_to_pdf(
     vg_spec: Py<PyAny>,
+    scale: Option<f64>,
     format_locale: Option<Py<PyAny>>,
     time_format_locale: Option<Py<PyAny>>,
     vega_plugin: Option<String>,
@@ -864,6 +882,7 @@ pub fn vega_to_pdf(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<Py<PyAny>> {
+    validate_pdf_scale(scale)?;
     let vg_spec = parse_json_spec(vg_spec)?;
     let format_locale = parse_option_format_locale(format_locale)?;
     let time_format_locale = parse_option_time_format_locale(time_format_locale)?;
@@ -903,6 +922,11 @@ pub fn vega_to_pdf(
 ///     vl_spec (str | dict): Vega-Lite JSON specification string or dict
 ///     vl_version (str): Vega-Lite library version string (e.g. 'v5.15')
 ///         (default to latest)
+///     scale (float):
+///         .. deprecated:: 2.0.0
+///            Retained only for backward compatibility with vl-convert 1.x.
+///            The parameter has no effect on PDF output. The only non-None
+///            value accepted is 1.0. Any other numeric value raises ValueError.
 ///     config (dict | None): Chart configuration object to apply during conversion
 ///     theme (str | None): Named theme (e.g. "dark") to apply during conversion
 ///     format_locale (str | dict): d3-format locale name or dictionary
@@ -919,6 +943,7 @@ pub fn vega_to_pdf(
     vl_spec,
     *,
     vl_version=None,
+    scale=None,
     config=None,
     theme=None,
     format_locale=None,
@@ -932,6 +957,7 @@ pub fn vega_to_pdf(
 pub fn vegalite_to_pdf(
     vl_spec: Py<PyAny>,
     vl_version: Option<&str>,
+    scale: Option<f64>,
     config: Option<Py<PyAny>>,
     theme: Option<String>,
     format_locale: Option<Py<PyAny>>,
@@ -942,6 +968,7 @@ pub fn vegalite_to_pdf(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<Py<PyAny>> {
+    validate_pdf_scale(scale)?;
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
     } else {
@@ -1238,11 +1265,17 @@ pub fn svg_to_jpeg(svg: &str, scale: Option<f32>, quality: Option<u8>) -> PyResu
 ///
 /// Args:
 ///     svg (str): SVG image string
+///     scale (float):
+///         .. deprecated:: 2.0.0
+///            Retained only for backward compatibility with vl-convert 1.x.
+///            The parameter has no effect on PDF output. The only non-None
+///            value accepted is 1.0. Any other numeric value raises ValueError.
 /// Returns:
 ///     bytes: PDF document data
 #[pyfunction]
-#[pyo3(signature = (svg))]
-pub fn svg_to_pdf(svg: &str) -> PyResult<Py<PyAny>> {
+#[pyo3(signature = (svg, *, scale=None))]
+pub fn svg_to_pdf(svg: &str, scale: Option<f64>) -> PyResult<Py<PyAny>> {
+    validate_pdf_scale(scale)?;
     let svg = svg.to_string();
     let pdf_data = run_converter_future(move |converter| async move {
         converter
@@ -1908,6 +1941,7 @@ pub fn vegalite_to_jpeg_asyncio<'py>(
 #[pyo3(signature = (
     vg_spec,
     *,
+    scale=None,
     format_locale=None,
     time_format_locale=None,
     vega_plugin=None,
@@ -1920,6 +1954,7 @@ pub fn vegalite_to_jpeg_asyncio<'py>(
 pub fn vega_to_pdf_asyncio<'py>(
     py: Python<'py>,
     vg_spec: Py<PyAny>,
+    scale: Option<f64>,
     format_locale: Option<Py<PyAny>>,
     time_format_locale: Option<Py<PyAny>>,
     vega_plugin: Option<String>,
@@ -1929,6 +1964,7 @@ pub fn vega_to_pdf_asyncio<'py>(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<Bound<'py, PyAny>> {
+    validate_pdf_scale(scale)?;
     let vg_spec = parse_json_spec(vg_spec)?;
     let format_locale = parse_option_format_locale(format_locale)?;
     let time_format_locale = parse_option_time_format_locale(time_format_locale)?;
@@ -1965,6 +2001,7 @@ pub fn vega_to_pdf_asyncio<'py>(
     vl_spec,
     *,
     vl_version=None,
+    scale=None,
     config=None,
     theme=None,
     format_locale=None,
@@ -1979,6 +2016,7 @@ pub fn vegalite_to_pdf_asyncio<'py>(
     py: Python<'py>,
     vl_spec: Py<PyAny>,
     vl_version: Option<&str>,
+    scale: Option<f64>,
     config: Option<Py<PyAny>>,
     theme: Option<String>,
     format_locale: Option<Py<PyAny>>,
@@ -1989,6 +2027,7 @@ pub fn vegalite_to_pdf_asyncio<'py>(
     width: Option<f32>,
     height: Option<f32>,
 ) -> PyResult<Bound<'py, PyAny>> {
+    validate_pdf_scale(scale)?;
     let vl_version = if let Some(vl_version) = vl_version {
         VlVersion::from_str(vl_version)?
     } else {
@@ -2281,8 +2320,13 @@ pub fn svg_to_jpeg_asyncio<'py>(
 
 #[doc = async_variant_doc!("svg_to_pdf")]
 #[pyfunction(name = "svg_to_pdf")]
-#[pyo3(signature = (svg))]
-pub fn svg_to_pdf_asyncio<'py>(py: Python<'py>, svg: &str) -> PyResult<Bound<'py, PyAny>> {
+#[pyo3(signature = (svg, *, scale=None))]
+pub fn svg_to_pdf_asyncio<'py>(
+    py: Python<'py>,
+    svg: &str,
+    scale: Option<f64>,
+) -> PyResult<Bound<'py, PyAny>> {
+    validate_pdf_scale(scale)?;
     let svg = svg.to_string();
     run_converter_future_async(
         py,

--- a/vl-convert-python/tests/test_asyncio.py
+++ b/vl-convert-python/tests/test_asyncio.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import pytest
 import vl_convert as vlc
@@ -93,16 +94,35 @@ def test_asyncio_smoke_and_sync_parity_shapes():
     run(scenario())
 
 
-def test_asyncio_pdf_rejects_scale_keyword():
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="PDF tests not supported on windows"
+)
+def test_asyncio_pdf_accepts_scale_one():
     async def scenario():
         vega = await vlca.vegalite_to_vega(SIMPLE_VL_SPEC, vl_version="v5_16")
         svg = await vlca.vegalite_to_svg(SIMPLE_VL_SPEC, vl_version="v5_16")
 
-        with pytest.raises(TypeError):
+        assert (await vlca.vega_to_pdf(vega, scale=1)).startswith(b"%PDF")
+        assert (
+            await vlca.vegalite_to_pdf(
+                SIMPLE_VL_SPEC, vl_version="v5_16", scale=1
+            )
+        ).startswith(b"%PDF")
+        assert (await vlca.svg_to_pdf(svg, scale=1)).startswith(b"%PDF")
+
+    run(scenario())
+
+
+def test_asyncio_pdf_rejects_scale_other_than_one():
+    async def scenario():
+        vega = await vlca.vegalite_to_vega(SIMPLE_VL_SPEC, vl_version="v5_16")
+        svg = await vlca.vegalite_to_svg(SIMPLE_VL_SPEC, vl_version="v5_16")
+
+        with pytest.raises(ValueError, match="scale argument must be 1"):
             await vlca.vega_to_pdf(vega, scale=2)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError, match="scale argument must be 1"):
             await vlca.vegalite_to_pdf(SIMPLE_VL_SPEC, vl_version="v5_16", scale=2)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError, match="scale argument must be 1"):
             await vlca.svg_to_pdf(svg, scale=2)
 
     run(scenario())

--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -365,18 +365,46 @@ def test_pdf(name, tol, as_dict):
     check_png(png, expected_png, tol=tol, name=f"pdf_vegalite_{name}")
 
 
-def test_pdf_rejects_scale_keyword():
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="PDF tests not supported on windows"
+)
+def test_pdf_accepts_scale_one():
     vl_version = "v5_8"
     vl_spec = load_vl_spec("circle_binned")
     vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
     svg = vlc.vegalite_to_svg(vl_spec, vl_version=vl_version)
 
-    with pytest.raises(TypeError):
-        vlc.vega_to_pdf(vg_spec, scale=2)
-    with pytest.raises(TypeError):
-        vlc.vegalite_to_pdf(vl_spec, vl_version=vl_version, scale=2)
-    with pytest.raises(TypeError):
-        vlc.svg_to_pdf(svg, scale=2)
+    assert vlc.vega_to_pdf(vg_spec, scale=1).startswith(b"%PDF")
+    assert vlc.vegalite_to_pdf(
+        vl_spec, vl_version=vl_version, scale=1
+    ).startswith(b"%PDF")
+    assert vlc.svg_to_pdf(svg, scale=1).startswith(b"%PDF")
+
+
+@pytest.mark.parametrize("scale", [0, 2, 1.0000000000000002, float("nan")])
+def test_pdf_rejects_scale_other_than_one(scale):
+    vl_version = "v5_8"
+    vl_spec = load_vl_spec("circle_binned")
+    vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
+    svg = vlc.vegalite_to_svg(vl_spec, vl_version=vl_version)
+
+    with pytest.raises(ValueError, match="scale argument must be 1"):
+        vlc.vega_to_pdf(vg_spec, scale=scale)
+    with pytest.raises(ValueError, match="scale argument must be 1"):
+        vlc.vegalite_to_pdf(vl_spec, vl_version=vl_version, scale=scale)
+    with pytest.raises(ValueError, match="scale argument must be 1"):
+        vlc.svg_to_pdf(svg, scale=scale)
+
+
+@pytest.mark.parametrize(
+    "function_name", ["vega_to_pdf", "vegalite_to_pdf", "svg_to_pdf"]
+)
+def test_pdf_scale_deprecation_in_docstring(function_name):
+    docstring = getattr(vlc, function_name).__doc__
+    normalized_docstring = " ".join(docstring.split())
+    assert ".. deprecated:: 2.0.0" in docstring
+    assert "Retained only for backward compatibility with vl-convert 1.x" in docstring
+    assert "The only non-None value accepted is 1.0" in normalized_docstring
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Font mismatch on windows")

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -637,7 +637,7 @@ def svg_to_jpeg(
     """
     ...
 
-def svg_to_pdf(svg: str) -> bytes:
+def svg_to_pdf(svg: str, *, scale: float | None = None) -> bytes:
     """
     Convert an SVG image string to PDF document data.
 
@@ -645,6 +645,11 @@ def svg_to_pdf(svg: str) -> bytes:
     ----------
     svg
         SVG image string
+    scale
+        .. deprecated:: 2.0.0
+           Retained only for backward compatibility with vl-convert 1.x.
+           The parameter has no effect on PDF output. The only non-None value
+           accepted is 1.0. Any other numeric value raises ``ValueError``.
 
     Returns
     -------
@@ -775,6 +780,7 @@ def vega_to_jpeg(
 def vega_to_pdf(
     vg_spec: VlSpec,
     *,
+    scale: float | None = None,
     format_locale: FormatLocale | None = None,
     time_format_locale: TimeFormatLocale | None = None,
     vega_plugin: str | None = None,
@@ -791,6 +797,11 @@ def vega_to_pdf(
     ----------
     vg_spec
         Vega JSON specification string or dict
+    scale
+        .. deprecated:: 2.0.0
+           Retained only for backward compatibility with vl-convert 1.x.
+           The parameter has no effect on PDF output. The only non-None value
+           accepted is 1.0. Any other numeric value raises ``ValueError``.
     format_locale
         d3-format locale name or dictionary
     time_format_locale
@@ -1173,6 +1184,7 @@ def vegalite_to_pdf(
     vl_spec: VlSpec,
     *,
     vl_version: str | None = None,
+    scale: float | None = None,
     config: dict[str, Any] | None = None,
     theme: VegaThemes | None = None,
     format_locale: FormatLocale | None = None,
@@ -1193,6 +1205,11 @@ def vegalite_to_pdf(
     vl_version
         Vega-Lite library version string (e.g. 'v5.15')
         (default to latest)
+    scale
+        .. deprecated:: 2.0.0
+           Retained only for backward compatibility with vl-convert 1.x.
+           The parameter has no effect on PDF output. The only non-None value
+           accepted is 1.0. Any other numeric value raises ``ValueError``.
     config
         Chart configuration object to apply during conversion
     theme
@@ -1558,7 +1575,7 @@ if TYPE_CHECKING:
         ) -> bytes:
             """Async version of ``svg_to_jpeg``. See sync function for full documentation."""
             ...
-        async def svg_to_pdf(self, svg: str) -> bytes:
+        async def svg_to_pdf(self, svg: str, *, scale: float | None = None) -> bytes:
             """Async version of ``svg_to_pdf``. See sync function for full documentation."""
             ...
         async def svg_to_png(
@@ -1604,6 +1621,7 @@ if TYPE_CHECKING:
             self,
             vg_spec: VlSpec,
             *,
+            scale: float | None = None,
             format_locale: FormatLocale | None = None,
             time_format_locale: TimeFormatLocale | None = None,
             vega_plugin: str | None = None,
@@ -1738,6 +1756,7 @@ if TYPE_CHECKING:
             vl_spec: VlSpec,
             *,
             vl_version: str | None = None,
+            scale: float | None = None,
             config: dict[str, Any] | None = None,
             theme: VegaThemes | None = None,
             format_locale: FormatLocale | None = None,


### PR DESCRIPTION
## Why

Altair's PDF export path always passes `scale=1` to vl-convert, including when callers use the default scale factor. VlConvert version 2 pre-releases had removed this keyword from the Python PDF functions because it was never actually supported (just ignored), so Altair PDF exports currently fail before conversion starts. This change restores compatibility with current Altair releases without requiring changes in Altair.

## What

The synchronous and asyncio versions of `vega_to_pdf()`, `vegalite_to_pdf()`, and `svg_to_pdf()` now accept the keyword-only `scale` parameter when the value is `None` or `1.0`. These values leave PDF output unchanged. Any other numeric value raises `ValueError`, because vl-convert has never applied scaling to vector PDF output.

The Python signatures and docstrings expose the compatibility parameter. Each docstring marks it as deprecated since 2.0.0 and states the accepted values and error behavior.
