### PR TITLE
fix: honor configured Google Fonts across conversions

### DIFF
--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -263,7 +263,10 @@ def test_png(name, scale, as_dict):
 
 
 def test_png_google_fonts():
-    vlc.configure(google_fonts=[{"family": "Bangers"}, {"family": "Lugrasimo"}])
+    vlc.configure(
+        google_fonts=[{"family": "Bangers"}, {"family": "Lugrasimo"}],
+        missing_fonts="error",
+    )
 
     vl_version = "v5_8"
     vl_spec = load_vl_spec("google_fonts")
@@ -275,6 +278,36 @@ def test_png_google_fonts():
 
     png = vlc.vegalite_to_png(vl_spec, vl_version=vl_version, scale=2)
     check_png(png, expected_png, name="png_vegalite_google_fonts")
+
+    svg = vlc.vegalite_to_svg(vl_spec, vl_version=vl_version)
+    assert vlc.svg_to_png(svg).startswith(b"\x89PNG\r\n\x1a\n")
+
+
+@pytest.mark.parametrize("bundle", [False, True])
+def test_html_configured_google_fonts(bundle):
+    vlc.configure(
+        google_fonts=[{"family": "Bangers"}, {"family": "Lugrasimo"}],
+        missing_fonts="error",
+    )
+
+    vl_version = "v5_8"
+    vl_spec = load_vl_spec("google_fonts")
+    vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
+
+    html_outputs = [
+        vlc.vega_to_html(vg_spec, bundle=bundle),
+        vlc.vegalite_to_html(vl_spec, vl_version=vl_version, bundle=bundle),
+    ]
+    for html in html_outputs:
+        if bundle:
+            assert "@font-face" in html
+            assert 'font-family: "Bangers"' in html
+            assert "base64," in html
+        else:
+            assert (
+                '<link rel="stylesheet" '
+                'href="https://fonts.googleapis.com/css2?family=Bangers:' in html
+            )
 
 
 @pytest.mark.parametrize(

--- a/vl-convert-python/tests/test_specs.py
+++ b/vl-convert-python/tests/test_specs.py
@@ -262,7 +262,7 @@ def test_png(name, scale, as_dict):
     check_png(png, expected_png, tol=tol, name=f"png_vegalite_{name}")
 
 
-def test_png_google_fonts():
+def test_configured_google_fonts():
     vlc.configure(
         google_fonts=[{"family": "Bangers"}, {"family": "Lugrasimo"}],
         missing_fonts="error",
@@ -279,35 +279,12 @@ def test_png_google_fonts():
     png = vlc.vegalite_to_png(vl_spec, vl_version=vl_version, scale=2)
     check_png(png, expected_png, name="png_vegalite_google_fonts")
 
-    svg = vlc.vegalite_to_svg(vl_spec, vl_version=vl_version)
-    assert vlc.svg_to_png(svg).startswith(b"\x89PNG\r\n\x1a\n")
+    html = vlc.vegalite_to_html(vl_spec, vl_version=vl_version, bundle=False)
 
-
-@pytest.mark.parametrize("bundle", [False, True])
-def test_html_configured_google_fonts(bundle):
-    vlc.configure(
-        google_fonts=[{"family": "Bangers"}, {"family": "Lugrasimo"}],
-        missing_fonts="error",
+    assert (
+        '<link rel="stylesheet" '
+        'href="https://fonts.googleapis.com/css2?family=Bangers:' in html
     )
-
-    vl_version = "v5_8"
-    vl_spec = load_vl_spec("google_fonts")
-    vg_spec = vlc.vegalite_to_vega(vl_spec, vl_version=vl_version)
-
-    html_outputs = [
-        vlc.vega_to_html(vg_spec, bundle=bundle),
-        vlc.vegalite_to_html(vl_spec, vl_version=vl_version, bundle=bundle),
-    ]
-    for html in html_outputs:
-        if bundle:
-            assert "@font-face" in html
-            assert 'font-family: "Bangers"' in html
-            assert "base64," in html
-        else:
-            assert (
-                '<link rel="stylesheet" '
-                'href="https://fonts.googleapis.com/css2?family=Bangers:' in html
-            )
 
 
 @pytest.mark.parametrize(

--- a/vl-convert-rs/src/converter/fonts.rs
+++ b/vl-convert-rs/src/converter/fonts.rs
@@ -135,6 +135,7 @@ pub(crate) fn google_font_request_key(request: &GoogleFontRequest) -> String {
 /// `fontdb` are requested.
 pub(crate) async fn classify_and_request_fonts(
     font_strings: HashSet<String>,
+    explicit_google_families: &HashSet<String>,
     auto_google_fonts: bool,
     missing_fonts: MissingFontsPolicy,
     prefer_cdn: bool,
@@ -143,19 +144,25 @@ pub(crate) async fn classify_and_request_fonts(
         return Ok(FontRequestAnalysis::default());
     }
 
-    let available = available_font_families()?;
+    let mut available = available_font_families()?;
 
     let font_string_vec: Vec<String> = font_strings.into_iter().collect();
 
     let mut google_fonts = GoogleFontUsage::default();
     let google_fonts_set: HashSet<String> = if auto_google_fonts {
-        let candidates = auto_google_probe_candidates(&font_string_vec, &available, prefer_cdn);
+        let mut candidates = auto_google_probe_candidates(&font_string_vec, &available, prefer_cdn);
+        candidates.retain(|family| !is_available(family, explicit_google_families));
         let catalog = google_font_catalog_matches(candidates.iter(), missing_fonts).await?;
         google_fonts.add_assign(&catalog.google_fonts);
         catalog.matches
     } else {
         HashSet::new()
     };
+
+    // Configured and per-call Google Fonts are resolved by the render overlay.
+    // Treat them as available during preflight so strict missing-font handling
+    // reports only families that no configured operation will provide.
+    available.extend(explicit_google_families.iter().cloned());
 
     // Classify each font string by its first entry
     let statuses = resolve_first_fonts(&font_string_vec, &available, |family| {
@@ -221,6 +228,7 @@ pub(crate) async fn classify_and_request_fonts(
 /// fonts via [`classify_and_request_fonts`].
 pub(crate) async fn preprocess_fonts(
     vega_spec: &serde_json::Value,
+    explicit_google_families: &HashSet<String>,
     auto_google_fonts: bool,
     missing_fonts: MissingFontsPolicy,
 ) -> Result<FontRequestAnalysis, AnyError> {
@@ -229,7 +237,14 @@ pub(crate) async fn preprocess_fonts(
     }
 
     let font_strings = extract_fonts_from_vega(vega_spec);
-    classify_and_request_fonts(font_strings, auto_google_fonts, missing_fonts, false).await
+    classify_and_request_fonts(
+        font_strings,
+        explicit_google_families,
+        auto_google_fonts,
+        missing_fonts,
+        false,
+    )
+    .await
 }
 
 /// Return all font family names currently available in fontdb.
@@ -271,14 +286,14 @@ pub(crate) fn auto_google_probe_candidates(
 
 /// Collect font family names from the rendered scenegraph that should be
 /// probed against Google Fonts. Excludes families already identified as
-/// explicit per-call Google Font requests.
+/// configured or per-call Google Font requests.
 pub(crate) fn scenegraph_google_probe_candidates(
     families: &BTreeSet<String>,
     explicit_google_families: &HashSet<String>,
 ) -> BTreeSet<String> {
     families
         .iter()
-        .filter(|family| !explicit_google_families.contains(*family))
+        .filter(|family| !is_available(family, explicit_google_families))
         .cloned()
         .collect()
 }
@@ -405,9 +420,9 @@ pub(crate) fn classify_as_google_font(family: &str) -> Option<ClassifiedFont> {
 /// Classify font families extracted from the scenegraph into Google Fonts
 /// or Local sources.
 ///
-/// `explicit_google_families` are families provided by per-call
-/// `GoogleFontRequest` entries -- they are classified as Google immediately
-/// without catalog probing and are excluded from missing-font reporting.
+/// `explicit_google_families` are families provided by configured or per-call
+/// `GoogleFontRequest` entries. They are classified as Google immediately,
+/// without catalog probing, and are excluded from missing-font reporting.
 ///
 /// Fonts that exist in the Google Fonts catalog are sourced from Google for
 /// portability (CDN links work on any machine). Remaining fonts are classified
@@ -444,8 +459,8 @@ pub(crate) async fn classify_scenegraph_fonts(
     let mut classified_fonts: Vec<ClassifiedFont> = Vec::new();
     let mut unavailable: Vec<String> = Vec::new();
     for family in families {
-        // Explicit per-call requests win immediately
-        if explicit_google_families.contains(family) {
+        // Explicit configured or per-call requests win immediately.
+        if is_available(family, explicit_google_families) {
             if let Some(font) = classify_as_google_font(family) {
                 classified_fonts.push(font);
             }
@@ -511,7 +526,7 @@ mod tests {
             "Bravo".to_string(),
             "Charlie".to_string(),
         ]);
-        let explicit = HashSet::from(["Bravo".to_string()]);
+        let explicit = HashSet::from(["bravo".to_string()]);
 
         let candidates = scenegraph_google_probe_candidates(&families, &explicit);
 
@@ -519,6 +534,24 @@ mod tests {
             candidates,
             BTreeSet::from(["Alpha".to_string(), "Charlie".to_string()])
         );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_google_font_satisfies_strict_preflight() {
+        let font_strings = HashSet::from(["VLC Explicit Test Font".to_string()]);
+        let explicit = HashSet::from(["vlc explicit test font".to_string()]);
+
+        let result = classify_and_request_fonts(
+            font_strings,
+            &explicit,
+            false,
+            MissingFontsPolicy::Error,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.requests.is_empty());
     }
 
     #[tokio::test]

--- a/vl-convert-rs/src/converter/mod.rs
+++ b/vl-convert-rs/src/converter/mod.rs
@@ -480,6 +480,22 @@ impl VlConverter {
             || self.inner.config().missing_fonts != MissingFontsPolicy::Fallback
     }
 
+    /// Return every Google Font family requested by converter configuration or
+    /// per-call options. These fonts are resolved before rendering and therefore
+    /// count as available during missing-font preflight.
+    pub(crate) fn explicit_google_families(
+        &self,
+        request_fonts: Option<&[GoogleFontRequest]>,
+    ) -> HashSet<String> {
+        self.inner
+            .config()
+            .google_fonts
+            .iter()
+            .chain(request_fonts.into_iter().flatten())
+            .map(|request| request.family.clone())
+            .collect()
+    }
+
     /// If font preprocessing is enabled, compile VL→Vega and process referenced fonts.
     ///
     /// Returns the compiled Vega spec, options, compile logs, and Google Fonts
@@ -507,8 +523,11 @@ impl VlConverter {
             .await?;
         let vega_spec = vega_output.spec;
         let compile_logs = vega_output.logs;
+        let explicit_google_families =
+            self.explicit_google_families(vl_opts.google_fonts.as_deref());
         let font_analysis = preprocess_fonts(
             &vega_spec,
+            &explicit_google_families,
             self.inner.config().auto_google_fonts,
             self.inner.config().missing_fonts,
         )
@@ -536,14 +555,17 @@ impl VlConverter {
     async fn maybe_preprocess_vega_fonts(
         &self,
         spec: &ValueOrString,
+        request_fonts: Option<&[GoogleFontRequest]>,
     ) -> Result<FontRequestAnalysis, AnyError> {
         if self.should_preprocess_fonts() {
             let spec_value: serde_json::Value = match spec {
                 ValueOrString::JsonString(s) => serde_json::from_str(s)?,
                 ValueOrString::Value(v) => v.clone(),
             };
+            let explicit_google_families = self.explicit_google_families(request_fonts);
             preprocess_fonts(
                 &spec_value,
+                &explicit_google_families,
                 self.inner.config().auto_google_fonts,
                 self.inner.config().missing_fonts,
             )
@@ -563,8 +585,10 @@ impl VlConverter {
         }
 
         let font_strings = crate::extract::extract_fonts_from_svg(svg);
+        let explicit_google_families = self.explicit_google_families(None);
         let font_analysis = classify_and_request_fonts(
             font_strings,
+            &explicit_google_families,
             self.inner.config().auto_google_fonts,
             self.inner.config().missing_fonts,
             false,
@@ -620,13 +644,12 @@ impl VlConverter {
         let vg_spec = vg_spec.into();
         let plugin = vg_opts.vega_plugin.take();
 
-        let explicit_google_families: HashSet<String> = vg_opts
-            .google_fonts
-            .as_ref()
-            .map(|reqs| reqs.iter().map(|r| r.family.clone()).collect())
-            .unwrap_or_default();
+        let explicit_google_families =
+            self.explicit_google_families(vg_opts.google_fonts.as_deref());
 
-        let font_analysis = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
+        let font_analysis = self
+            .maybe_preprocess_vega_fonts(&vg_spec, vg_opts.google_fonts.as_deref())
+            .await?;
         if !font_analysis.requests.is_empty() {
             vg_opts
                 .google_fonts
@@ -780,7 +803,9 @@ impl VlConverter {
     ) -> Result<ScenegraphOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
-        let font_analysis = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
+        let font_analysis = self
+            .maybe_preprocess_vega_fonts(&vg_spec, vg_opts.google_fonts.as_deref())
+            .await?;
         if !font_analysis.requests.is_empty() {
             vg_opts
                 .google_fonts
@@ -808,7 +833,9 @@ impl VlConverter {
     ) -> Result<ScenegraphMsgpackOutput, AnyError> {
         self.apply_vg_defaults(&mut vg_opts);
         let vg_spec = vg_spec.into();
-        let font_analysis = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
+        let font_analysis = self
+            .maybe_preprocess_vega_fonts(&vg_spec, vg_opts.google_fonts.as_deref())
+            .await?;
         if !font_analysis.requests.is_empty() {
             vg_opts
                 .google_fonts
@@ -843,11 +870,8 @@ impl VlConverter {
         let vl_spec = vl_spec.into();
         let plugin = vl_opts.vega_plugin.take();
 
-        let explicit_google_families: HashSet<String> = vl_opts
-            .google_fonts
-            .as_ref()
-            .map(|reqs| reqs.iter().map(|r| r.family.clone()).collect())
-            .unwrap_or_default();
+        let explicit_google_families =
+            self.explicit_google_families(vl_opts.google_fonts.as_deref());
 
         let mut output =
             if let Some((vega_spec, mut vg_opts, compile_logs, preprocess_google_fonts)) = self
@@ -1024,7 +1048,9 @@ impl VlConverter {
         let effective_scale = scale * ppi / 72.0;
         let plugin = vg_opts.vega_plugin.take();
 
-        let font_analysis = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
+        let font_analysis = self
+            .maybe_preprocess_vega_fonts(&vg_spec, vg_opts.google_fonts.as_deref())
+            .await?;
         if !font_analysis.requests.is_empty() {
             vg_opts
                 .google_fonts
@@ -1165,7 +1191,9 @@ impl VlConverter {
         let vg_spec = vg_spec.into();
         let plugin = vg_opts.vega_plugin.take();
 
-        let font_analysis = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
+        let font_analysis = self
+            .maybe_preprocess_vega_fonts(&vg_spec, vg_opts.google_fonts.as_deref())
+            .await?;
         if !font_analysis.requests.is_empty() {
             vg_opts
                 .google_fonts
@@ -1311,7 +1339,9 @@ impl VlConverter {
         let vg_spec = vg_spec.into();
         let plugin = vg_opts.vega_plugin.take();
 
-        let font_analysis = self.maybe_preprocess_vega_fonts(&vg_spec).await?;
+        let font_analysis = self
+            .maybe_preprocess_vega_fonts(&vg_spec, vg_opts.google_fonts.as_deref())
+            .await?;
         if !font_analysis.requests.is_empty() {
             vg_opts
                 .google_fonts

--- a/vl-convert-rs/src/html.rs
+++ b/vl-convert-rs/src/html.rs
@@ -343,8 +343,16 @@ impl VlConverter {
 
         if auto_google_fonts || missing != MissingFontsPolicy::Fallback {
             let font_strings = extract_fonts_from_vega(&vega_spec);
-            let analysis =
-                classify_and_request_fonts(font_strings, auto_google_fonts, missing, true).await?;
+            let explicit_google_families =
+                self.explicit_google_families(vg_opts.google_fonts.as_deref());
+            let analysis = classify_and_request_fonts(
+                font_strings,
+                &explicit_google_families,
+                auto_google_fonts,
+                missing,
+                true,
+            )
+            .await?;
             google_fonts.add_assign(analysis.google_fonts);
             if !analysis.requests.is_empty() {
                 vg_opts
@@ -377,8 +385,8 @@ impl VlConverter {
     }
 
     /// Render the Vega scenegraph, walk it in Rust to extract text-by-font
-    /// data, classify fonts as Google or Local, and merge any explicit
-    /// per-request Google Font overrides.
+    /// data, classify fonts as Google or Local, and merge configured and
+    /// per-call Google Font requests.
     ///
     /// This is the single point of truth for font analysis. Called once per
     /// HTML generation or `vega_fonts` / `vegalite_fonts` invocation.
@@ -391,7 +399,12 @@ impl VlConverter {
     ) -> Result<FontAnalysis, AnyError> {
         let missing = self.inner.config().missing_fonts;
 
-        let explicit_requests = vg_opts.google_fonts.clone();
+        let explicit_google_families =
+            self.explicit_google_families(vg_opts.google_fonts.as_deref());
+        let mut explicit_requests = self.inner.config().google_fonts.clone();
+        if let Some(requests) = &vg_opts.google_fonts {
+            explicit_requests.extend(requests.iter().cloned());
+        }
         let format_locale_value = vg_opts
             .format_locale
             .as_ref()
@@ -416,11 +429,6 @@ impl VlConverter {
 
         let families: BTreeSet<String> = chars_by_key.keys().map(|k| k.family.clone()).collect();
 
-        let explicit_google_families: HashSet<String> = explicit_requests
-            .as_ref()
-            .map(|reqs| reqs.iter().map(|r| r.family.clone()).collect())
-            .unwrap_or_default();
-
         let classified = classify_scenegraph_fonts(
             &families,
             auto_google_fonts,
@@ -435,23 +443,21 @@ impl VlConverter {
 
         let mut family_variants = variants_by_family(&chars_by_key);
 
-        if let Some(ref requests) = explicit_requests {
-            let known: HashSet<String> =
-                classified_fonts.iter().map(|f| f.family.clone()).collect();
-            for req in requests {
-                if !known.contains(&req.family) {
-                    if let Some(font_id) = family_to_id(&req.family) {
-                        classified_fonts.push(ClassifiedFont {
-                            family: req.family.clone(),
-                            source: FontSource::Google { font_id },
-                        });
-                    }
+        let mut known: HashSet<String> =
+            classified_fonts.iter().map(|f| f.family.clone()).collect();
+        for req in &explicit_requests {
+            if known.insert(req.family.clone()) {
+                if let Some(font_id) = family_to_id(&req.family) {
+                    classified_fonts.push(ClassifiedFont {
+                        family: req.family.clone(),
+                        source: FontSource::Google { font_id },
+                    });
                 }
-                if let Some(ref variants) = req.variants {
-                    let entry = family_variants.entry(req.family.clone()).or_default();
-                    for v in variants {
-                        entry.insert((v.weight.to_string(), v.style.as_str().to_string()));
-                    }
+            }
+            if let Some(ref variants) = req.variants {
+                let entry = family_variants.entry(req.family.clone()).or_default();
+                for v in variants {
+                    entry.insert((v.weight.to_string(), v.style.as_str().to_string()));
                 }
             }
         }
@@ -802,7 +808,11 @@ impl VlConverter {
         let auto_install = self.inner.config().auto_google_fonts;
         let embed_local = self.inner.config().embed_local_fonts;
 
-        let has_font_work = auto_install || embed_local || vl_opts.google_fonts.is_some();
+        let has_font_work = auto_install
+            || embed_local
+            || !self
+                .explicit_google_families(vl_opts.google_fonts.as_deref())
+                .is_empty();
         let mut logs = Vec::new();
         let mut google_fonts = GoogleFontUsage::default();
         let font_head_html = if has_font_work {
@@ -888,7 +898,11 @@ impl VlConverter {
         let auto_install = self.inner.config().auto_google_fonts;
         let embed_local = self.inner.config().embed_local_fonts;
 
-        let has_font_work = auto_install || embed_local || vg_opts.google_fonts.is_some();
+        let has_font_work = auto_install
+            || embed_local
+            || !self
+                .explicit_google_families(vg_opts.google_fonts.as_deref())
+                .is_empty();
         let mut google_fonts = GoogleFontUsage::default();
         let font_head_html = if has_font_work {
             let spec_value: serde_json::Value = match &vg_spec {

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -704,10 +704,10 @@ mod test_png_no_theme {
 }
 
 #[rustfmt::skip]
-mod test_png_google_fonts {
+mod test_configured_google_fonts {
     use crate::*;
     use futures::executor::block_on;
-    use vl_convert_rs::converter::{GoogleFontRequest, MissingFontsPolicy, VlcConfig, VlOpts};
+    use vl_convert_rs::converter::{GoogleFontRequest, HtmlOpts, MissingFontsPolicy, Renderer, VgOpts, VlcConfig, VlOpts};
 
     #[test]
     fn test() {
@@ -736,82 +736,38 @@ mod test_png_google_fonts {
         ).unwrap();
         check_png("google_fonts", vl_version, None, output.data.as_slice());
 
-        let output = block_on(converter.vega_to_svg(vg_output.spec, Default::default(), SvgOpts::default())).unwrap();
-        assert!(output.svg.starts_with("<svg"));
-
         let output = block_on(
-            converter.vegalite_to_svg(vl_spec, VlOpts{vl_version, ..Default::default()}, SvgOpts::default())
+            converter.vegalite_to_svg(vl_spec.clone(), VlOpts{vl_version, ..Default::default()}, SvgOpts::default())
         ).unwrap();
-        assert!(output.svg.starts_with("<svg"));
+        assert!(output.svg.contains("@import"));
+        assert!(output.svg.contains("fonts.googleapis.com"));
+        assert!(output.svg.contains("Bangers"));
 
         let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="40">
             <text x="0" y="30" font-family="Bangers">Configured font</text>
         </svg>"#;
         let output = block_on(converter.svg_to_png(svg, PngOpts::default())).unwrap();
         assert_eq!(&output.data[..8], b"\x89PNG\r\n\x1a\n");
-    }
 
-    #[test]
-    fn test_marker() {} // Help IDE detect test module
-}
+        let vl_html = block_on(
+            converter.vegalite_to_html(
+                vl_spec,
+                VlOpts { vl_version, ..Default::default() },
+                HtmlOpts { bundle: false, renderer: Renderer::Svg },
+            )
+        ).unwrap();
+        assert!(vl_html.html.contains("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Bangers:"));
 
-#[rustfmt::skip]
-mod test_html_configured_google_fonts {
-    use crate::*;
-    use futures::executor::block_on;
-    use serde_json::json;
-    use vl_convert_rs::converter::{GoogleFontRequest, HtmlOpts, MissingFontsPolicy, Renderer, VgOpts, VlcConfig, VlOpts};
-
-    fn check_html(html: &str, bundle: bool) {
-        if bundle {
-            assert!(html.contains("@font-face"));
-            assert!(html.contains("font-family: \"Bangers\""));
-            assert!(html.contains("base64,"));
-        } else {
-            assert!(html.contains("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Bangers:"));
-        }
-    }
-
-    #[test]
-    fn test() {
-        initialize();
-
-        let vl_version = VlVersion::v5_8;
-        let vl_spec = json!({
-            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-            "data": {"values": [{"category": "A", "value": 1}]},
-            "mark": "bar",
-            "encoding": {
-                "x": {"field": "category", "type": "nominal"},
-                "y": {"field": "value", "type": "quantitative"}
-            },
-            "title": "Configured Google Font",
-            "config": {"title": {"font": "Bangers"}}
-        });
-        let converter = VlConverter::with_config(VlcConfig {
-            google_fonts: vec![GoogleFontRequest {
-                family: "Bangers".to_string(),
-                variants: None,
-            }],
-            missing_fonts: MissingFontsPolicy::Error,
-            ..Default::default()
-        }).unwrap();
-        let vg_spec = block_on(
-            converter.vegalite_to_vega(vl_spec.clone(), VlOpts { vl_version, ..Default::default() })
-        ).unwrap().spec;
-
-        for bundle in [false, true] {
-            let html_opts = HtmlOpts { bundle, renderer: Renderer::Svg };
-            let vl_html = block_on(
-                converter.vegalite_to_html(vl_spec.clone(), VlOpts { vl_version, ..Default::default() }, html_opts.clone())
-            ).unwrap();
-            check_html(&vl_html.html, bundle);
-
-            let vg_html = block_on(
-                converter.vega_to_html(vg_spec.clone(), VgOpts::default(), html_opts)
-            ).unwrap();
-            check_html(&vg_html.html, bundle);
-        }
+        let vg_html = block_on(
+            converter.vega_to_html(
+                vg_output.spec,
+                VgOpts::default(),
+                HtmlOpts { bundle: true, renderer: Renderer::Svg },
+            )
+        ).unwrap();
+        assert!(vg_html.html.contains("@font-face"));
+        assert!(vg_html.html.contains("font-family: \"Bangers\""));
+        assert!(vg_html.html.contains("base64,"));
     }
 
     #[test]

--- a/vl-convert-rs/tests/test_specs.rs
+++ b/vl-convert-rs/tests/test_specs.rs
@@ -707,7 +707,7 @@ mod test_png_no_theme {
 mod test_png_google_fonts {
     use crate::*;
     use futures::executor::block_on;
-    use vl_convert_rs::converter::{GoogleFontRequest, VlcConfig, VlOpts};
+    use vl_convert_rs::converter::{GoogleFontRequest, MissingFontsPolicy, VlcConfig, VlOpts};
 
     #[test]
     fn test() {
@@ -720,6 +720,7 @@ mod test_png_google_fonts {
                 GoogleFontRequest { family: "Bangers".to_string(), variants: None },
                 GoogleFontRequest { family: "Lugrasimo".to_string(), variants: None },
             ],
+            missing_fonts: MissingFontsPolicy::Error,
             ..Default::default()
         }).unwrap();
 
@@ -727,13 +728,90 @@ mod test_png_google_fonts {
             converter.vegalite_to_vega(vl_spec.clone(), VlOpts{vl_version, ..Default::default()})
         ).unwrap();
 
-        let output = block_on(converter.vega_to_png(vg_output.spec, Default::default(), PngOpts { scale: Some(2.0), ppi: None })).unwrap();
+        let output = block_on(converter.vega_to_png(vg_output.spec.clone(), Default::default(), PngOpts { scale: Some(2.0), ppi: None })).unwrap();
         check_png("google_fonts", vl_version, None, output.data.as_slice());
 
         let output = block_on(
-            converter.vegalite_to_png(vl_spec, VlOpts{vl_version, ..Default::default()}, PngOpts { scale: Some(2.0), ppi: None })
+            converter.vegalite_to_png(vl_spec.clone(), VlOpts{vl_version, ..Default::default()}, PngOpts { scale: Some(2.0), ppi: None })
         ).unwrap();
         check_png("google_fonts", vl_version, None, output.data.as_slice());
+
+        let output = block_on(converter.vega_to_svg(vg_output.spec, Default::default(), SvgOpts::default())).unwrap();
+        assert!(output.svg.starts_with("<svg"));
+
+        let output = block_on(
+            converter.vegalite_to_svg(vl_spec, VlOpts{vl_version, ..Default::default()}, SvgOpts::default())
+        ).unwrap();
+        assert!(output.svg.starts_with("<svg"));
+
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="40">
+            <text x="0" y="30" font-family="Bangers">Configured font</text>
+        </svg>"#;
+        let output = block_on(converter.svg_to_png(svg, PngOpts::default())).unwrap();
+        assert_eq!(&output.data[..8], b"\x89PNG\r\n\x1a\n");
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
+}
+
+#[rustfmt::skip]
+mod test_html_configured_google_fonts {
+    use crate::*;
+    use futures::executor::block_on;
+    use serde_json::json;
+    use vl_convert_rs::converter::{GoogleFontRequest, HtmlOpts, MissingFontsPolicy, Renderer, VgOpts, VlcConfig, VlOpts};
+
+    fn check_html(html: &str, bundle: bool) {
+        if bundle {
+            assert!(html.contains("@font-face"));
+            assert!(html.contains("font-family: \"Bangers\""));
+            assert!(html.contains("base64,"));
+        } else {
+            assert!(html.contains("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Bangers:"));
+        }
+    }
+
+    #[test]
+    fn test() {
+        initialize();
+
+        let vl_version = VlVersion::v5_8;
+        let vl_spec = json!({
+            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "data": {"values": [{"category": "A", "value": 1}]},
+            "mark": "bar",
+            "encoding": {
+                "x": {"field": "category", "type": "nominal"},
+                "y": {"field": "value", "type": "quantitative"}
+            },
+            "title": "Configured Google Font",
+            "config": {"title": {"font": "Bangers"}}
+        });
+        let converter = VlConverter::with_config(VlcConfig {
+            google_fonts: vec![GoogleFontRequest {
+                family: "Bangers".to_string(),
+                variants: None,
+            }],
+            missing_fonts: MissingFontsPolicy::Error,
+            ..Default::default()
+        }).unwrap();
+        let vg_spec = block_on(
+            converter.vegalite_to_vega(vl_spec.clone(), VlOpts { vl_version, ..Default::default() })
+        ).unwrap().spec;
+
+        for bundle in [false, true] {
+            let html_opts = HtmlOpts { bundle, renderer: Renderer::Svg };
+            let vl_html = block_on(
+                converter.vegalite_to_html(vl_spec.clone(), VlOpts { vl_version, ..Default::default() }, html_opts.clone())
+            ).unwrap();
+            check_html(&vl_html.html, bundle);
+
+            let vg_html = block_on(
+                converter.vega_to_html(vg_spec.clone(), VgOpts::default(), html_opts)
+            ).unwrap();
+            check_html(&vg_html.html, bundle);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

Converter-level Google Font requests currently produce inconsistent results. Static conversions with `missing_fonts="error"` reject a requested family before the explicitly configured font overlay is applied. Direct HTML conversions don't perform font analysis for converter-level requests, so they omit the requested font from the generated HTML. These failures make the process-wide `google_fonts` setting unreliable.

## What

Font preflight now combines converter-level and per-call Google Font requests into one effective family set. It excludes these families from automatic catalog probes and treats them as available during missing-font validation. The Google Fonts resolver still reports an error if it cannot load an explicit request.

Direct Vega and Vega-Lite HTML conversions now process converter-level Google Font requests. Unbundled HTML includes the corresponding Google Fonts stylesheet link, while bundled HTML includes embedded `@font-face` data. SVG postprocessing uses the same effective family set so configured requests remain valid during strict font checks and reach generated SVG output.

## Tour

[`vl-convert-rs/src/converter/mod.rs`](https://github.com/vega/vl-convert/pull/295/files#diff-66a13b2a3b4afdf6531465a3fbb00db05f0ed89b6101e038320a24383ba301ef) collects configured and per-call Google Font families at each conversion entry point. It passes the effective set through Vega, Vega-Lite, SVG, and scenegraph preflight before the render overlay resolves the requested fonts.

[`vl-convert-rs/src/converter/fonts.rs`](https://github.com/vega/vl-convert/pull/295/files#diff-6b06b9f1de58d02b171808fcef04c57dbb407aea1176fcb0708294e0a78a9b83) removes explicit requests from automatic probes and treats them as available during strict missing-font validation. The scenegraph classifier applies the same case-insensitive match so HTML and SVG processing classify configured requests as Google Fonts.

[`vl-convert-rs/src/html.rs`](https://github.com/vega/vl-convert/pull/295/files#diff-b2e372cd8f04c87ce05fbd1f2e856946006464b0422b82e81a302ab1c1c1005a) starts font analysis when either converter-level or per-call Google Fonts are present. It merges both request sources before it builds stylesheet links or embedded font data. Focused Rust and Python tests verify strict configured-font rendering and direct Vega and Vega-Lite HTML output in bundled and unbundled modes.

