### PR TITLE
feat: accept Vega-Lite version strings with patch numbers

### DIFF
--- a/vl-convert-rs/src/module_loader/import_map.rs
+++ b/vl-convert-rs/src/module_loader/import_map.rs
@@ -96,7 +96,18 @@ impl FromStr for VlVersion {
     type Err = AnyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
+        let version = match s.rsplit_once('.') {
+            Some((major_minor, patch))
+                if major_minor.contains('.')
+                    && !patch.is_empty()
+                    && patch.bytes().all(|b| b.is_ascii_digit())
+                    && (patch == "0" || !patch.starts_with('0')) =>
+            {
+                major_minor
+            }
+            _ => s,
+        };
+        Ok(match version {
             "5.8" | "v5.8" | "5_8" | "v5_8" => Self::v5_8,
             "5.14" | "v5.14" | "5_14" | "v5_14" => Self::v5_14,
             "5.15" | "v5.15" | "5_15" | "v5_15" => Self::v5_15,

--- a/vl-convert-rs/tests/test_vl_version.rs
+++ b/vl-convert-rs/tests/test_vl_version.rs
@@ -1,0 +1,41 @@
+use vl_convert_rs::module_loader::import_map::VL_VERSIONS;
+use vl_convert_rs::VlVersion;
+
+#[test]
+fn test_vl_version_aliases_and_patch_versions() {
+    for &version in VL_VERSIONS {
+        let major_minor = version.to_semver();
+        let underscored = major_minor.replace('.', "_");
+        for input in [
+            major_minor.to_string(),
+            format!("v{major_minor}"),
+            underscored.clone(),
+            format!("v{underscored}"),
+            format!("{major_minor}.0"),
+            format!("{major_minor}.123"),
+            format!("v{major_minor}.1"),
+        ] {
+            assert_eq!(input.parse::<VlVersion>().unwrap(), version, "{input}");
+        }
+    }
+}
+
+#[test]
+fn test_vl_version_rejects_invalid_or_unsupported_versions() {
+    for input in [
+        "",
+        "6",
+        "99.99.1",
+        "6.4.",
+        "6.4.1.2",
+        "6.4.-1",
+        "6.4.01",
+        "6.4.x",
+        "6.4.1-rc.1",
+        "6.4.1+build",
+        "6_4_1",
+        " 6.4.1",
+    ] {
+        assert!(input.parse::<VlVersion>().is_err(), "{input}");
+    }
+}

--- a/vl-convert-vendor/src/main.rs
+++ b/vl-convert-vendor/src/main.rs
@@ -416,7 +416,18 @@ impl FromStr for VlVersion {{
     type Err = AnyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {{
-        Ok(match s {{
+        let version = match s.rsplit_once('.') {{
+            Some((major_minor, patch))
+                if major_minor.contains('.')
+                    && !patch.is_empty()
+                    && patch.bytes().all(|b| b.is_ascii_digit())
+                    && (patch == "0" || !patch.starts_with('0')) =>
+            {{
+                major_minor
+            }}
+            _ => s,
+        }};
+        Ok(match version {{
             {from_str_matches_csv},
             _ => bail!("Unsupported Vega-Lite version string {{}}", s)
         }})


### PR DESCRIPTION
## Why

Altair users cannot pass `alt.VEGALITE_VERSION` directly to VlConvert because it includes a patch number, such as `6.4.1`. They must first reduce the string to `6.4`.

## What

The shared Rust version parser now accepts `major.minor.patch` strings with an optional `v` prefix. It ignores the numeric patch component and selects the bundled compiler for the major/minor version. For example, `6.4.1` selects the bundled 6.4.3 compiler. Callers can use `vl_version=alt.VEGALITE_VERSION` without changes to Altair or the Python wrappers.

Existing major/minor aliases keep their behavior. Unsupported major/minor pairs and malformed strings remain errors. Prerelease and build suffixes are not accepted.