### PR TITLE
chore: prepare v2.0.0-rc6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10853,7 +10853,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vl-convert"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "assert_cmd",
  "bytes",
@@ -10882,7 +10882,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-canvas2d"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "cosmic-text",
  "csscolorparser",
@@ -10901,7 +10901,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-canvas2d-deno"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "csscolorparser",
  "deno_core",
@@ -10917,7 +10917,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-google-fonts"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "backon",
  "dashmap 6.2.1",
@@ -10936,7 +10936,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-python"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "futures",
  "lazy_static",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-rs"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "arc-swap",
  "backon",
@@ -11004,7 +11004,7 @@ dependencies = [
 
 [[package]]
 name = "vl-convert-server"
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0-rc5"
+version = "2.0.0-rc6"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/vega/vl-convert"
@@ -32,11 +32,11 @@ backon = { version = "1", default-features = false, features = ["tokio-sleep", "
 clap = { version = "4.5", features = ["derive", "env"] }
 
 # Internal packages are released in lockstep.
-vl-convert-canvas2d = { path = "vl-convert-canvas2d", version = "=2.0.0-rc5" }
-vl-convert-canvas2d-deno = { path = "vl-convert-canvas2d-deno", version = "=2.0.0-rc5" }
-vl-convert-google-fonts = { path = "vl-convert-google-fonts", version = "=2.0.0-rc5" }
-vl-convert-rs = { path = "vl-convert-rs", version = "=2.0.0-rc5" }
-vl-convert-server = { path = "vl-convert-server", version = "=2.0.0-rc5" }
+vl-convert-canvas2d = { path = "vl-convert-canvas2d", version = "=2.0.0-rc6" }
+vl-convert-canvas2d-deno = { path = "vl-convert-canvas2d-deno", version = "=2.0.0-rc6" }
+vl-convert-google-fonts = { path = "vl-convert-google-fonts", version = "=2.0.0-rc6" }
+vl-convert-rs = { path = "vl-convert-rs", version = "=2.0.0-rc6" }
+vl-convert-server = { path = "vl-convert-server", version = "=2.0.0-rc6" }
 
 # Deno dependencies - versions correspond to Deno v2.9.6
 deno_runtime = "0.266.0"


### PR DESCRIPTION
## Summary

Prepare `2.0.0-rc6` as a prerelease. This updates the shared workspace version and exact internal package requirements from `2.0.0-rc5`.

## Packages

- `vl-convert`
- `vl-convert-canvas2d`
- `vl-convert-canvas2d-deno`
- `vl-convert-google-fonts`
- `vl-convert-python`
- `vl-convert-rs`
- `vl-convert-server`

## After merge

- Wait for all required CI checks on `main`.
- Create a GitHub Release with a new `v2.0.0-rc6` tag that targets `main`.
- Mark it as a prerelease when the version contains a prerelease component.
- Publish the GitHub Release to start package and artifact publishing.
