### PR TITLE
build: update Vega datasets to 3.2.1

### DIFF
--- a/vl-convert-rs/src/converter/config.rs
+++ b/vl-convert-rs/src/converter/config.rs
@@ -1,4 +1,5 @@
 use crate::data_ops::{normalize_allowed_base_url, AllowedBaseUrlPattern};
+use crate::module_loader::import_map::{url_for_path, VEGA_DATASETS_PATH};
 use deno_core::anyhow::{anyhow, bail};
 use deno_core::error::AnyError;
 use deno_core::url::Url;
@@ -87,9 +88,7 @@ impl BaseUrlSetting {
     /// Filesystem paths are converted to file:// URLs.
     pub fn resolved_url(&self) -> Result<Option<String>, AnyError> {
         match self {
-            Self::Default => Ok(Some(
-                "https://cdn.jsdelivr.net/npm/vega-datasets@v2.9.0/".to_string(),
-            )),
+            Self::Default => Ok(Some(url_for_path(VEGA_DATASETS_PATH))),
             Self::Disabled => Ok(None),
             Self::Custom(url) => {
                 if !is_filesystem_path(url) && Url::parse(url).is_ok() {
@@ -579,6 +578,10 @@ mod tests {
     #[test]
     fn default_config_values() {
         let cfg = VlcConfig::default();
+        assert_eq!(
+            cfg.base_url.resolved_url().unwrap(),
+            Some(url_for_path(VEGA_DATASETS_PATH))
+        );
         assert_eq!(cfg.num_workers.get(), 1, "num_workers default is 1");
         assert_eq!(
             cfg.allowed_base_urls,

--- a/vl-convert-rs/src/module_loader/import_map.rs
+++ b/vl-convert-rs/src/module_loader/import_map.rs
@@ -10,6 +10,7 @@ pub const JSDELIVR_URL: &str = "https://cdn.jsdelivr.net";
 pub const VEGA_PATH: &str = "/npm/vega@6.4.0/+esm";
 pub const VEGA_THEMES_PATH: &str = "/npm/vega-themes@3.0.0/+esm";
 pub const VEGA_EMBED_PATH: &str = "/npm/vega-embed@7.2.0/+esm";
+pub const VEGA_DATASETS_PATH: &str = "/npm/vega-datasets@v3.2.1/";
 pub const DEBOUNCE_PATH: &str = "/npm/lodash.debounce@4.0.8/+esm";
 pub const MSGPACK_PATH: &str = "/npm/@msgpack/msgpack@3.1.3/+esm";
 

--- a/vl-convert-vendor/README.md
+++ b/vl-convert-vendor/README.md
@@ -36,7 +36,7 @@ To update the Vega version:
 
 # Updating the Vega datasets version
 
-Update `VEGA_DATASETS_PATH` alongside the other dependency pins in `vl-convert-vendor/src/main.rs`, then run `pixi run vendor`. The generated constant sets the default base URL for relative data and image URLs. Dataset files are loaded from the CDN at runtime, not bundled with vl-convert.
+Update `VEGA_DATASETS_PATH` alongside the other dependency pins in `vl-convert-vendor/src/main.rs`. Run `pixi run vendor` to regenerate the constant that sets the default base URL for relative data and image URLs. Dataset files are loaded from the CDN at runtime, not bundled with vl-convert.
 
 # Removing old Vega-Lite versions
 When removing old versions (e.g., versions not used by any Altair release):

--- a/vl-convert-vendor/README.md
+++ b/vl-convert-vendor/README.md
@@ -1,7 +1,7 @@
 # Overview
 `vl-convert-vendor` is a helper crate that downloads multiple versions of Vega-Lite, and their dependencies, using Deno's vendoring feature. It also generates the `vl-convert-rs/src/module_loader/import_map.rs` file which inlines the source code of all the downloaded dependencies using the `include_str!` macro.
 
-This crate only needs to be run when a new Vega-Lite version is to be added or Vega is updated.
+Run this crate when updating the dependency pins in `src/main.rs`, including the default `vega-datasets` CDN version.
 
 # Run
 
@@ -33,6 +33,10 @@ To update the Vega version:
 1. Update `VEGA_PATH` in `vl-convert-vendor/src/main.rs`: `/npm/vega@X.Y.Z/+esm`
 2. Run `pixi run vendor`
 3. Run tests to verify compatibility
+
+# Updating the Vega datasets version
+
+Update `VEGA_DATASETS_PATH` alongside the other dependency pins in `vl-convert-vendor/src/main.rs`, then run `pixi run vendor`. The generated constant sets the default base URL for relative data and image URLs. Dataset files are loaded from the CDN at runtime, not bundled with vl-convert.
 
 # Removing old Vega-Lite versions
 When removing old versions (e.g., versions not used by any Altair release):

--- a/vl-convert-vendor/src/main.rs
+++ b/vl-convert-vendor/src/main.rs
@@ -36,6 +36,7 @@ const JSDELIVR_URL: &str = "https://cdn.jsdelivr.net";
 const VEGA_PATH: &str = "/npm/vega@6.4.0/+esm";
 const VEGA_THEMES_PATH: &str = "/npm/vega-themes@3.0.0/+esm";
 const VEGA_EMBED_PATH: &str = "/npm/vega-embed@7.2.0/+esm";
+const VEGA_DATASETS_PATH: &str = "/npm/vega-datasets@v3.2.1/";
 const DEBOUNCE_PATH: &str = "/npm/lodash.debounce@4.0.8/+esm";
 const MSGPACK_PATH: &str = "/npm/@msgpack/msgpack@3.1.3/+esm";
 
@@ -354,6 +355,7 @@ pub const JSDELIVR_URL: &str = "{JSDELIVR_URL}";
 pub const VEGA_PATH: &str = "{VEGA_PATH}";
 pub const VEGA_THEMES_PATH: &str = "{VEGA_THEMES_PATH}";
 pub const VEGA_EMBED_PATH: &str = "{VEGA_EMBED_PATH}";
+pub const VEGA_DATASETS_PATH: &str = "{VEGA_DATASETS_PATH}";
 pub const DEBOUNCE_PATH: &str = "{DEBOUNCE_PATH}";
 pub const MSGPACK_PATH: &str = "{MSGPACK_PATH}";
 


### PR DESCRIPTION
## Why

Charts with relative data URLs use a default CDN URL pinned to `vega-datasets` 2.9.0. The latest published version is 3.2.1, which Altair also uses. The existing pin is hardcoded in converter configuration, separate from the dependency pins used during vendoring.

## What

Updates the default dataset version to 3.2.1 and moves its pin to `VEGA_DATASETS_PATH` alongside the Vega, Vega-Lite, and Vega-Embed pins. Future updates use the same workflow: change the pin and run `pixi run vendor`.

Dataset files still load from the CDN at runtime. They are not bundled with vl-convert. Absolute data URLs and custom `base_url` settings are unchanged.

## Tour

`BaseUrlSetting::Default` in [`vl-convert-rs/src/converter/config.rs`](https://github.com/vega/vl-convert/pull/298/files#diff-aa54cca9871bbace2690c1df0ccddef1a0d2366e40f3f5e0cef4f2fa12805a37) builds the CDN URL from the generated dataset path. The existing default-configuration test checks that it uses this pin. All 21 configuration tests passed. A live rendering check loaded `data/cars.json` with only the 3.2.1 CDN prefix allowed and rendered the expected count of 406 rows. The same check confirmed that custom and disabled base URLs are unchanged.

[`vl-convert-vendor/src/main.rs`](https://github.com/vega/vl-convert/pull/298/files#diff-4fdd506c6db132c272e9f5133e8d64814edc52bffe1850b3ad8c0ffa4ccc9b91) declares the path and emits it into the import map. Running `pixi run vendor` regenerated the constant without changing any bundled JavaScript or locale files.

