### PR TITLE
feat!: resolve absolute data and image paths as local files

### DIFF
--- a/vl-convert-rs/src/converter/inner/init.rs
+++ b/vl-convert-rs/src/converter/inner/init.rs
@@ -106,8 +106,28 @@ function buildLoader(errors) {
     const loader = vega.loader({ baseURL });
     const originalSanitize = loader.sanitize.bind(loader);
 
-    loader.load = async (uri, options) => {
+    loader.sanitize = async (uri, options) => {
+        let fileUrl;
+        if (typeof uri === 'string' && options?.context !== 'href') {
+            const windowsPath = globalThis.Deno?.build?.os === 'windows'
+                && /^[A-Za-z]:[\\/]/.test(uri);
+            if (windowsPath || (uri.startsWith('/') && !uri.startsWith('//'))) {
+                const path = windowsPath ? uri.slice(2).replaceAll('\\', '/') : uri;
+                const prefix = windowsPath ? `file:///${uri.slice(0, 2)}` : 'file://';
+                fileUrl = prefix + path.split('/').map(encodeURIComponent).join('/');
+                uri = fileUrl;
+            }
+        }
         const sanitized = await originalSanitize(uri, options);
+        // Image readers need the file scheme to decode escaped path characters.
+        if (fileUrl && options?.context === 'image') {
+            sanitized.href = fileUrl;
+        }
+        return sanitized;
+    };
+
+    loader.load = async (uri, options) => {
+        const sanitized = await loader.sanitize(uri, options);
         const href = sanitized.href;
         const responseType = options?.http?.response;
         const wantBinary = responseType === 'arraybuffer';
@@ -517,5 +537,62 @@ function vegaLiteToCanvas_{ver_name}(vlSpec, config, theme, formatLocale, timeFo
             self.initialized_vl_versions.insert(*vl_version);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::converter::{ConverterContext, VlcConfig};
+    use crate::text::get_font_baseline_snapshot;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_absolute_path_sanitization() {
+        let mut converter = InnerVlConverter::try_new(
+            Arc::new(ConverterContext {
+                config: VlcConfig::default(),
+                parsed_allowed_base_urls: Vec::new(),
+                resolved_plugins: Vec::new(),
+            }),
+            get_font_baseline_snapshot().unwrap(),
+        )
+        .await
+        .unwrap();
+        converter.init_vega().await.unwrap();
+        converter.execute_script_to_json(r#"
+            var pathChecks;
+            (async () => {
+                const loader = buildLoader([]);
+                const cases = [
+                    ['/data/a #%.csv', 'data', '/data/a%20%23%25.csv', true],
+                    ['/data/a #%.png', 'image', 'file:///data/a%20%23%25.png', true],
+                    ['//example.com/a.csv', 'data', 'http://example.com/a.csv', false],
+                    ['a.csv', 'data', 'https://example.com/a.csv', false],
+                    ['/chart', 'href', 'https://example.com/chart', false],
+                    ['file:///data/a.csv', 'data', '/data/a.csv', true],
+                ];
+                if (Deno.build.os === 'windows') {
+                    cases.push(
+                        ['C:\\data\\a #%.csv', 'data', '/C:/data/a%20%23%25.csv', true],
+                        ['C:/data/a.png', 'image', 'file:///C:/data/a.png', true],
+                    );
+                }
+                pathChecks = await Promise.all(cases.map(async ([uri, context, href, localFile]) => {
+                    const result = await loader.sanitize(uri, {context, baseURL: 'https://example.com'});
+                    return result.href === href && result.localFile === localFile;
+                }));
+            })();
+            null;
+        "#).await.unwrap();
+        let checks = converter
+            .execute_script_to_json("pathChecks")
+            .await
+            .unwrap();
+        assert!(
+            checks.as_array().unwrap().iter().all(|v| *v == json!(true)),
+            "{checks}"
+        );
     }
 }

--- a/vl-convert-rs/tests/test_config.rs
+++ b/vl-convert-rs/tests/test_config.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 use std::collections::HashMap;
-use vl_convert_rs::converter::{SvgOpts, VlOpts, VlcConfig};
+use vl_convert_rs::converter::{BaseUrlSetting, PngOpts, SvgOpts, VlOpts, VlcConfig};
 use vl_convert_rs::VlConverter;
 
 fn simple_vl_bar_spec() -> serde_json::Value {
@@ -200,4 +200,73 @@ async fn test_per_request_locale_overrides_default() {
         "Per-request en-US locale should produce English formatting. Got: {}",
         &output.svg[..output.svg.len().min(500)]
     );
+}
+
+#[tokio::test]
+async fn test_absolute_data_path_uses_allowlist_without_base_url() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("data #100%.csv");
+    std::fs::write(&path, "label\nloaded\n").unwrap();
+    let spec = json!({
+        "data": {"url": path},
+        "mark": "text",
+        "encoding": {"text": {"field": "label"}}
+    });
+    for base_url in [BaseUrlSetting::Default, BaseUrlSetting::Disabled] {
+        for allowed in [false, true] {
+            let converter = VlConverter::with_config(VlcConfig {
+                base_url: base_url.clone(),
+                allowed_base_urls: if allowed {
+                    vec![directory.path().to_string_lossy().into_owned()]
+                } else {
+                    vec![]
+                },
+                ..Default::default()
+            })
+            .unwrap();
+            let result = converter
+                .vegalite_to_svg(spec.clone(), VlOpts::default(), SvgOpts::default())
+                .await;
+            if allowed {
+                assert!(result.unwrap().svg.contains(">loaded</text>"));
+            } else {
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Filesystem access denied"));
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_absolute_image_path_preserves_escaped_characters() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("image #100%.png");
+    let mut image = tiny_skia::Pixmap::new(2, 2).unwrap();
+    image.fill(tiny_skia::Color::from_rgba8(255, 0, 0, 255));
+    image.save_png(&path).unwrap();
+    let converter = VlConverter::with_config(VlcConfig {
+        allowed_base_urls: vec![directory.path().to_string_lossy().into_owned()],
+        ..Default::default()
+    })
+    .unwrap();
+    let spec = json!({
+        "data": {"values": [{}]},
+        "mark": {"type": "image", "width": 20, "height": 20},
+        "encoding": {"url": {"value": path}}
+    });
+    let png = converter
+        .vegalite_to_png(spec.clone(), VlOpts::default(), PngOpts::default())
+        .await
+        .unwrap();
+    let pixels = image::load_from_memory(&png.data).unwrap().to_rgba8();
+    assert!(pixels.pixels().any(|p| p.0 == [255, 0, 0, 255]));
+
+    let svg = converter
+        .vegalite_to_svg(spec, VlOpts::default(), SvgOpts::default())
+        .await
+        .unwrap();
+    let file_url = deno_core::url::Url::from_file_path(path).unwrap();
+    assert!(svg.svg.contains(file_url.as_str()));
 }


### PR DESCRIPTION
## Why

VlConvert v1.9 currently resolves bare absolute paths in chart specifications against `base_url`. With the default configuration, `/srv/data/cars.csv` becomes a CDN URL, even when the user has allowed the local directory. Users must convert filesystem paths to `file://` URLs before passing them to Vega or Altair.

## What

VlConvert now interprets absolute data and image paths as local files before Vega resolves relative URLs. This includes paths beginning with a single `/` and, on Windows, drive-qualified paths such as `C:\data\cars.csv` and `C:/data/cars.csv`. Users can keep the default `base_url` and pass an absolute path directly. Local reads still require an allowed directory.

Relative URLs, explicit URLs, protocol-relative URLs such as `//example.com/data.csv`, and chart hyperlinks retain their existing resolution behavior. Specifications that use `/data/cars.csv` as a remote reference relative to `base_url` should drop the leading forward slash.