### PR TITLE
fix!: standardize Google Fonts environment variable names

### DIFF
--- a/vl-convert-google-fonts/README.md
+++ b/vl-convert-google-fonts/README.md
@@ -13,3 +13,14 @@ This crate provides a client for downloading and caching fonts from the [Google 
 | Feature  | Description |
 |----------|-------------|
 | `fontdb` | Adds `GoogleFontsDatabaseExt` trait for registering/unregistering font batches on a `fontdb::Database` |
+
+## Environment Variables
+
+These variables configure the shared Google Fonts client in Python, Rust, the CLI, and the server. Set them before the client is initialized.
+
+| Variable | Effect |
+| --- | --- |
+| `VLC_GOOGLE_FONTS_CACHE_DIR` | Absolute cache directory for downloaded fonts and CSS. Set to `none` to disable disk caching. Defaults to the platform cache directory plus `vl-convert/google-fonts`. |
+| `VLC_GOOGLE_FONTS_CSS2_URL` | Google Fonts CSS2 endpoint, for a mirror or local test server. Defaults to `https://fonts.googleapis.com/css2`. |
+
+These replace the prerelease names `VL_CONVERT_FONT_CACHE_DIR` and `VL_CONVERT_GOOGLE_FONTS_CSS2_URL`, which are no longer recognized. Rust callers can also set the corresponding fields in `ClientConfig` directly.

--- a/vl-convert-google-fonts/src/config.rs
+++ b/vl-convert-google-fonts/src/config.rs
@@ -9,12 +9,12 @@ const DEFAULT_MAX_RETRIES: usize = 3;
 ///
 /// Set to a path to override the default cache location.
 /// Set to `"none"` to disable persistent caching entirely (in-memory only).
-const ENV_FONT_CACHE_DIR: &str = "VL_CONVERT_FONT_CACHE_DIR";
+const ENV_FONT_CACHE_DIR: &str = "VLC_GOOGLE_FONTS_CACHE_DIR";
 
 /// Environment variable to override the Google Fonts CSS2 API base URL.
 ///
 /// Set to a URL to use a custom mirror or local test server.
-const ENV_GOOGLE_FONTS_CSS2_URL: &str = "VL_CONVERT_GOOGLE_FONTS_CSS2_URL";
+const ENV_GOOGLE_FONTS_CSS2_URL: &str = "VLC_GOOGLE_FONTS_CSS2_URL";
 
 /// Runtime configuration for [`GoogleFontsClient`](crate::GoogleFontsClient).
 ///
@@ -51,8 +51,8 @@ impl ClientConfig {
 /// Returns the resolved Google Fonts cache directory, or `None` if caching is disabled.
 ///
 /// Resolution order:
-/// 1. `VL_CONVERT_FONT_CACHE_DIR` env var set to `"none"` → `None`
-/// 2. `VL_CONVERT_FONT_CACHE_DIR` env var set to a path → `Some(path)`
+/// 1. `VLC_GOOGLE_FONTS_CACHE_DIR` env var set to `"none"` → `None`
+/// 2. `VLC_GOOGLE_FONTS_CACHE_DIR` env var set to a path → `Some(path)`
 /// 3. OS cache dir fallback → `Some(<cache_dir>/vl-convert/google-fonts)`
 pub fn google_fonts_cache_dir() -> Option<PathBuf> {
     match std::env::var(ENV_FONT_CACHE_DIR) {

--- a/vl-convert-google-fonts/tests/environment_config.rs
+++ b/vl-convert-google-fonts/tests/environment_config.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+use vl_convert_google_fonts::{google_fonts_cache_dir, ClientConfig};
+
+#[test]
+fn environment_config() {
+    if let Ok(case) = std::env::var("VLC_TEST_FONT_CONFIG") {
+        let config = ClientConfig::default();
+        let expected_cache = match case.as_str() {
+            "path" => Some(std::env::temp_dir().join("vlc font cache")),
+            "disabled" => None,
+            "default" => dirs::cache_dir().map(|p| p.join("vl-convert/google-fonts")),
+            _ => panic!("Unknown test case: {case}"),
+        };
+        assert_eq!(config.cache_dir, expected_cache);
+        assert_eq!(google_fonts_cache_dir(), expected_cache);
+        assert_eq!(
+            config.google_fonts_css2_url,
+            if case == "default" {
+                "https://fonts.googleapis.com/css2"
+            } else {
+                "http://127.0.0.1:12345/css2"
+            }
+        );
+        return;
+    }
+
+    // Child processes keep environment changes isolated from parallel tests.
+    for case in ["default", "path", "disabled"] {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args(["--exact", "environment_config"])
+            .env("VLC_TEST_FONT_CONFIG", case)
+            .env_remove("VLC_GOOGLE_FONTS_CACHE_DIR")
+            .env_remove("VLC_GOOGLE_FONTS_CSS2_URL")
+            .env("VL_CONVERT_FONT_CACHE_DIR", "ignored legacy cache")
+            .env(
+                "VL_CONVERT_GOOGLE_FONTS_CSS2_URL",
+                "http://legacy.invalid/css2",
+            );
+        if case != "default" {
+            command
+                .env(
+                    "VLC_GOOGLE_FONTS_CACHE_DIR",
+                    if case == "path" {
+                        std::env::temp_dir().join("vlc font cache").into_os_string()
+                    } else {
+                        "NoNe".into()
+                    },
+                )
+                .env("VLC_GOOGLE_FONTS_CSS2_URL", "http://127.0.0.1:12345/css2");
+        }
+        let output = command.output().unwrap();
+        assert!(output.status.success(), "{case}: {output:?}");
+    }
+}

--- a/vl-convert-python/src/fonts.rs
+++ b/vl-convert-python/src/fonts.rs
@@ -322,9 +322,9 @@ pub fn set_google_fonts_cache_size_mb(max_size_mb: Option<u64>) -> PyResult<()> 
 ///
 /// Resolved once per process from the environment:
 ///
-/// 1. ``VL_CONVERT_FONT_CACHE_DIR=none``: ``None`` (caching disabled,
+/// 1. ``VLC_GOOGLE_FONTS_CACHE_DIR=none``: ``None`` (caching disabled,
 ///    fonts always fetched fresh).
-/// 2. ``VL_CONVERT_FONT_CACHE_DIR=/some/path``: that path.
+/// 2. ``VLC_GOOGLE_FONTS_CACHE_DIR=/some/path``: that path.
 /// 3. Unset: the OS cache directory joined with ``vl-convert/google-fonts``
 ///    (e.g. ``~/Library/Caches/vl-convert/google-fonts`` on macOS).
 ///

--- a/vl-convert-python/vl_convert.pyi
+++ b/vl-convert-python/vl_convert.pyi
@@ -363,9 +363,9 @@ def google_fonts_cache_dir() -> str | None:
 
     Resolved once per process from the environment:
 
-    1. ``VL_CONVERT_FONT_CACHE_DIR=none``: ``None`` (caching disabled,
+    1. ``VLC_GOOGLE_FONTS_CACHE_DIR=none``: ``None`` (caching disabled,
        fonts always fetched fresh).
-    2. ``VL_CONVERT_FONT_CACHE_DIR=/some/path``: that path.
+    2. ``VLC_GOOGLE_FONTS_CACHE_DIR=/some/path``: that path.
     3. Unset: the OS cache directory joined with ``vl-convert/google-fonts``
        (e.g. ``~/Library/Caches/vl-convert/google-fonts`` on macOS).
 


### PR DESCRIPTION
## Why

Users configuring vl-convert currently encounter two environment variable prefixes: `VL_CONVERT_*` for the shared Google Fonts client and `VLC_*` for CLI and server settings. The cache directory variable also omits `GOOGLE_FONTS`, unlike the existing `VLC_GOOGLE_FONTS_CACHE_SIZE_MB` setting. This PR makes the names consistent during the 2.0 prerelease period.

## What

This PR renames `VL_CONVERT_FONT_CACHE_DIR` to `VLC_GOOGLE_FONTS_CACHE_DIR` and `VL_CONVERT_GOOGLE_FONTS_CSS2_URL` to `VLC_GOOGLE_FONTS_CSS2_URL`. The old names are no longer recognized. Update existing environment settings to retain a custom cache directory, disabled disk caching, or a custom CSS2 endpoint.
